### PR TITLE
Fix crash when userinfo_endpoint is not set

### DIFF
--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -246,6 +246,10 @@ end
 
 -- make a call to the userinfo endpoint
 local function openidc_call_userinfo_endpoint(opts, access_token)
+  if not opts.discovery.userinfo_endpoint then
+    ngx.log(ngx.DEBUG, "no userinfo endpoint supplied")
+    return nil, nil
+  end
 
   local httpc = http.new()
   local res, err = httpc:request_uri(opts.discovery.userinfo_endpoint, {


### PR DESCRIPTION
Not all OpenID Connect providers supply the userinfo endpoint (e.g. [dex](https://github.com/coreos/dex/)). This is according to [spec](https://openid.net/specs/openid-connect-discovery-_0.html#ProviderMetadata):

```
userinfo_endpoint
    RECOMMENDED. URL of the OP's UserInfo Endpoint [OpenID.Core]. This URL MUST use the https scheme and MAY contain port, path, and query parameter components.
```