### PR TITLE
Add Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
 
 script:
   - luarocks pack $ROCKSPEC
+  - luarocks upload $ROCKSPEC --api-key=$API_KEY # The API key comes from an environment variable configured on https://travis-ci.org/
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+language: c
+
+sudo: false
+
+env:
+  global:
+    - NAME=lua-resty-openidc
+    - VERSION=1.1-0
+    - LUAROCKS=2.3.0
+  matrix:
+    - LUA=lua5.1
+
+before_install:
+  - source .travis/setenv_lua.sh
+  - luarocks install Lua-cURL --server=https://luarocks.org/dev
+  - luarocks install lunitx
+
+install:
+  - luarocks make $NAME-$VERSION.rockspec CFLAGS="-O2 -fPIC -fprofile-arcs" LIBFLAG="-shared"
+  - sudo luarocks install luasocket
+  - luarocks install lua-resty-http
+  - luarocks install lua-resty-http
+  - luarocks install lua-resty-session
+  - luarocks install lua-resty-jwt
+  - luarocks install lua-resty-hmac
+
+script:
+  - luarocks pack lua-resty-openidc-1.1-0.rockspec
+
+notifications:
+  email:
+    on_success: change
+    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ sudo: false
 
 env:
   global:
-    - NAME=lua-resty-openidc
     - VERSION=1.1-0
+    - NAME=lua-resty-openidc
+    - ROCKSPEC=$NAME-$VERSION.rockspec
     - LUAROCKS=2.3.0
   matrix:
     - LUA=lua5.1
@@ -16,7 +17,7 @@ before_install:
   - luarocks install lunitx
 
 install:
-  - luarocks make $NAME-$VERSION.rockspec CFLAGS="-O2 -fPIC -fprofile-arcs" LIBFLAG="-shared"
+  - luarocks make $ROCKSPEC CFLAGS="-O2 -fPIC -fprofile-arcs" LIBFLAG="-shared"
   - luarocks install luasocket
   - luarocks install lua-resty-http
   - luarocks install lua-resty-http
@@ -25,7 +26,7 @@ install:
   - luarocks install lua-resty-hmac
 
 script:
-  - luarocks pack lua-resty-openidc-1.1-0.rockspec
+  - luarocks pack $ROCKSPEC
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
   - source .travis/setenv_lua.sh
   - luarocks install Lua-cURL --server=https://luarocks.org/dev
   - luarocks install lunitx
+  - luarocks install JSON4Lua
 
 install:
   - luarocks make $ROCKSPEC CFLAGS="-O2 -fPIC -fprofile-arcs" LIBFLAG="-shared"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 
 install:
   - luarocks make $NAME-$VERSION.rockspec CFLAGS="-O2 -fPIC -fprofile-arcs" LIBFLAG="-shared"
-  - sudo luarocks install luasocket
+  - luarocks install luasocket
   - luarocks install lua-resty-http
   - luarocks install lua-resty-http
   - luarocks install lua-resty-session

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,6 @@ before_install:
 
 install:
   - luarocks make $ROCKSPEC CFLAGS="-O2 -fPIC -fprofile-arcs" LIBFLAG="-shared"
-  - luarocks install luasocket
-  - luarocks install lua-resty-http
-  - luarocks install lua-resty-http
-  - luarocks install lua-resty-session
-  - luarocks install lua-resty-jwt
-  - luarocks install lua-resty-hmac
 
 script:
   - luarocks pack $ROCKSPEC

--- a/.travis/platform.sh
+++ b/.travis/platform.sh
@@ -1,0 +1,15 @@
+if [ -z "${PLATFORM:-}" ]; then
+  PLATFORM=$TRAVIS_OS_NAME;
+fi
+
+if [ "$PLATFORM" == "osx" ]; then
+  PLATFORM="macosx";
+fi
+
+if [ -z "$PLATFORM" ]; then
+  if [ "$(uname)" == "Linux" ]; then
+    PLATFORM="linux";
+  else
+    PLATFORM="macosx";
+  fi;
+fi

--- a/.travis/setenv_lua.sh
+++ b/.travis/setenv_lua.sh
@@ -1,0 +1,3 @@
+export PATH=${PATH}:$HOME/.lua:$HOME/.local/bin:${TRAVIS_BUILD_DIR}/install/luarocks/bin
+bash .travis/setup_lua.sh
+eval `$HOME/.lua/luarocks path`

--- a/.travis/setup_lua.sh
+++ b/.travis/setup_lua.sh
@@ -1,0 +1,122 @@
+#! /bin/bash
+
+# A script for setting up environment for travis-ci testing.
+# Sets up Lua and Luarocks.
+# LUA must be "lua5.1", "lua5.2" or "luajit".
+# luajit2.0 - master v2.0
+# luajit2.1 - master v2.1
+
+set -eufo pipefail
+
+LUAJIT_VERSION="2.0.4"
+LUAJIT_BASE="LuaJIT-$LUAJIT_VERSION"
+
+source .travis/platform.sh
+
+LUA_HOME_DIR=$TRAVIS_BUILD_DIR/install/lua
+
+LR_HOME_DIR=$TRAVIS_BUILD_DIR/install/luarocks
+
+mkdir $HOME/.lua
+
+LUAJIT="no"
+
+if [ "$PLATFORM" == "macosx" ]; then
+  if [ "$LUA" == "luajit" ]; then
+    LUAJIT="yes";
+  fi
+  if [ "$LUA" == "luajit2.0" ]; then
+    LUAJIT="yes";
+  fi
+  if [ "$LUA" == "luajit2.1" ]; then
+    LUAJIT="yes";
+  fi;
+elif [ "$(expr substr $LUA 1 6)" == "luajit" ]; then
+  LUAJIT="yes";
+fi
+
+mkdir -p "$LUA_HOME_DIR"
+
+if [ "$LUAJIT" == "yes" ]; then
+
+  if [ "$LUA" == "luajit" ]; then
+    curl --location https://github.com/LuaJIT/LuaJIT/archive/v$LUAJIT_VERSION.tar.gz | tar xz;
+  else
+    git clone https://github.com/LuaJIT/LuaJIT.git $LUAJIT_BASE;
+  fi
+
+  cd $LUAJIT_BASE
+
+  if [ "$LUA" == "luajit2.1" ]; then
+    git checkout v2.1;
+    # force the INSTALL_TNAME to be luajit
+    perl -i -pe 's/INSTALL_TNAME=.+/INSTALL_TNAME= luajit/' Makefile
+  fi
+
+  make && make install PREFIX="$LUA_HOME_DIR"
+
+  ln -s $LUA_HOME_DIR/bin/luajit $HOME/.lua/luajit
+  ln -s $LUA_HOME_DIR/bin/luajit $HOME/.lua/lua;
+
+else
+
+  if [ "$LUA" == "lua5.1" ]; then
+    curl http://www.lua.org/ftp/lua-5.1.5.tar.gz | tar xz
+    cd lua-5.1.5;
+  elif [ "$LUA" == "lua5.2" ]; then
+    curl http://www.lua.org/ftp/lua-5.2.4.tar.gz | tar xz
+    cd lua-5.2.4;
+  elif [ "$LUA" == "lua5.3" ]; then
+    curl http://www.lua.org/ftp/lua-5.3.2.tar.gz | tar xz
+    cd lua-5.3.2;
+  fi
+
+  # Build Lua without backwards compatibility for testing
+  perl -i -pe 's/-DLUA_COMPAT_(ALL|5_2)//' src/Makefile
+  make $PLATFORM
+  make INSTALL_TOP="$LUA_HOME_DIR" install;
+
+  ln -s $LUA_HOME_DIR/bin/lua $HOME/.lua/lua
+  ln -s $LUA_HOME_DIR/bin/luac $HOME/.lua/luac;
+
+fi
+
+cd $TRAVIS_BUILD_DIR
+
+lua -v
+
+LUAROCKS_BASE=luarocks-$LUAROCKS
+
+curl --location http://luarocks.org/releases/$LUAROCKS_BASE.tar.gz | tar xz
+
+cd $LUAROCKS_BASE
+
+if [ "$LUA" == "luajit" ]; then
+  ./configure --lua-suffix=jit --with-lua-include="$LUA_HOME_DIR/include/luajit-2.0" --prefix="$LR_HOME_DIR";
+elif [ "$LUA" == "luajit2.0" ]; then
+  ./configure --lua-suffix=jit --with-lua-include="$LUA_HOME_DIR/include/luajit-2.0" --prefix="$LR_HOME_DIR";
+elif [ "$LUA" == "luajit2.1" ]; then
+  ./configure --lua-suffix=jit --with-lua-include="$LUA_HOME_DIR/include/luajit-2.1" --prefix="$LR_HOME_DIR";
+else
+  ./configure --with-lua="$LUA_HOME_DIR" --prefix="$LR_HOME_DIR"
+fi
+
+make build && make install
+
+ln -s $LR_HOME_DIR/bin/luarocks $HOME/.lua/luarocks
+
+cd $TRAVIS_BUILD_DIR
+
+luarocks --version
+
+rm -rf $LUAROCKS_BASE
+
+if [ "$LUAJIT" == "yes" ]; then
+  rm -rf $LUAJIT_BASE;
+elif [ "$LUA" == "lua5.1" ]; then
+  rm -rf lua-5.1.5;
+elif [ "$LUA" == "lua5.2" ]; then
+  rm -rf lua-5.2.4;
+elif [ "$LUA" == "lua5.3" ]; then
+  rm -rf lua-5.3.2;
+fi


### PR DESCRIPTION
This PR adds a [Travis build](https://travis-ci.org/asbjornu/lua-resty-openidc) to the project so the `.rockspec` is automatically built and uploaded to [LuaRocks](https://luarocks.org/modules/asbjornu/lua-resty-openidc) on every commit. Before merging this:

- @ping-identity's [Travis build for this repository](https://travis-ci.org/pingidentity/lua-resty-openidc) should be enabled. The one I link to above is my personal Travis project.
- Someone affiliated with @ping-identity should create a LuaRocks profile and get an API key from [the settings page](https://luarocks.org/settings/api-keys), so the rock is uploaded to a more "official" profile. The currently uploaded module belongs to my personal account, which isn't ideal.
- This API key must be configured in the [settings of the Travis project](https://travis-ci.org/pingidentity/lua-resty-openidc/settings) with the name `API_KEY` so it is made available to the `.travis.yml` file.

There's only one snag about this, which is that the `luarocks upload` command will fail if the package already exists for that version number. Ideally, every commit on the `master` branch should lead to a new version, and we could get this as a variable from `git tag` instead of hard coded in `.travis.yml` like now, but that requires some discipline on the maintainers of this project that I don't know if can be mandated.

Thoughts?