### PR TITLE
Add Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.project
+*.rock

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,6 @@ script:
   # TODO: Add some integration tests that excersice the OAuth and OpenID Connect
   # interface of lua-resty-openidc.
 
-after_success:
-  # The Lua Rocks API key comes from an environment variable configured on
-  # https://travis-ci.org/
-  - luarocks upload $ROCKSPEC --api-key=$API_KEY
-
 deploy:
   provider: releases
   # The GitHub OAuth Token comes from an environment variable configured on
@@ -55,6 +50,11 @@ deploy:
   on:
     # repo: asbjornu/lua-resty-openidc
     tags: true
+
+after_deploy:
+  # The Lua Rocks API key comes from an environment variable configured on
+  # https://travis-ci.org/
+  - luarocks upload $ROCKSPEC --api-key=$API_KEY
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,16 +22,21 @@ before_install:
 
 install:
   - luarocks make $ROCKSPEC CFLAGS="-O2 -fPIC -fprofile-arcs" LIBFLAG="-shared"
+  # TODO: We need to inject the current rock of lua-resty-openidc into the Docker container.
+  #       It will now just fetch the latest one from luarocks.org.
   - docker build -t lua-resty-openidc .
   - docker run -d -p 127.0.0.1:80:80 --name lua-resty-openidc lua-resty-openidc
 
 script:
   - docker ps | grep -q lua-resty-openidc
-  # TODO: Add some integration tests that excersice the OAuth and OpenID Connect interface.
+  # TODO: Add some integration tests that excersice the OAuth and OpenID Connect
+  # interface of lua-resty-openidc.
 
 after_success:
   - luarocks pack $ROCKSPEC
-  - luarocks upload $ROCKSPEC --api-key=$API_KEY # The API key comes from an environment variable configured on https://travis-ci.org/
+  # The API key comes from an environment variable configured on
+  # https://travis-ci.org/
+  - luarocks upload $ROCKSPEC --api-key=$API_KEY
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ env:
   matrix:
     - LUA=lua5.1
 
+services:
+    - docker
+
 before_install:
   - source .travis/setenv_lua.sh
   - luarocks install Lua-cURL --server=https://luarocks.org/dev
@@ -19,8 +22,14 @@ before_install:
 
 install:
   - luarocks make $ROCKSPEC CFLAGS="-O2 -fPIC -fprofile-arcs" LIBFLAG="-shared"
+  - docker build -t lua-resty-openidc .
+  - docker run -d -p 127.0.0.1:80:80 --name lua-resty-openidc lua-resty-openidc
 
 script:
+  - docker ps | grep -q lua-resty-openidc
+  # TODO: Add some integration tests that excersice the OAuth and OpenID Connect interface.
+
+after_success:
   - luarocks pack $ROCKSPEC
   - luarocks upload $ROCKSPEC --api-key=$API_KEY # The API key comes from an environment variable configured on https://travis-ci.org/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,7 @@ sudo: false
 
 env:
   global:
-    - VERSION=1.2.0-1
     - NAME=lua-resty-openidc
-    - ROCKSPEC=$NAME-$VERSION.rockspec
-    - ROCK=$NAME-$VERSION.src.rock
     - LUAROCKS=2.3.0
   matrix:
     - LUA=lua5.1
@@ -16,6 +13,9 @@ services:
     - docker
 
 before_install:
+  - VERSION=`git describe | grep -oP '[\d\.]+\-\d+'`
+  - ROCKSPEC=$NAME-$VERSION.rockspec
+  - ROCK=$NAME-$VERSION.src.rock
   - source .travis/setenv_lua.sh
   - luarocks install Lua-cURL --server=https://luarocks.org/dev
   - luarocks install lunitx

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,20 @@ script:
   # interface of lua-resty-openidc.
 
 after_success:
-  # The API key comes from an environment variable configured on
+  # The Lua Rocks API key comes from an environment variable configured on
   # https://travis-ci.org/
   - luarocks upload $ROCKSPEC --api-key=$API_KEY
+
+deploy:
+  provider: releases
+  # The GitHub OAuth Token comes from an environment variable configured on
+  # https://travis-ci.org/
+  api_key: $GITHUB_OAUTH_TOKEN
+  file: $ROCK
+  skip_cleanup: true
+  on:
+    # repo: asbjornu/lua-resty-openidc
+    tags: true
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
 
 script:
   - docker run -d -p 127.0.0.1:80:80 --name $NAME $NAME
-  - docker ps | grep -q $NAME
+  - docker ps | grep $NAME
   # TODO: Add some integration tests that excersice the OAuth and OpenID Connect
   # interface of lua-resty-openidc.
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,11 @@ install:
   # Append RUN command to install the copied rock:
   - echo "RUN /usr/local/openresty/luajit/bin/luarocks install ${ROCK}" >> Dockerfile
   - cat Dockerfile
-  - docker build -t lua-resty-openidc .
+  - docker build -t $NAME .
 
 script:
-  - docker run -d -p 127.0.0.1:80:80 --name lua-resty-openidc lua-resty-openidc
-  - docker ps | grep -q lua-resty-openidc
+  - docker run -d -p 127.0.0.1:80:80 --name $NAME $NAME
+  - docker ps | grep -q $NAME
   # TODO: Add some integration tests that excersice the OAuth and OpenID Connect
   # interface of lua-resty-openidc.
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
   - mv $NAME.rockspec $ROCKSPEC
   - sed -i -e "s/\${VERSION}/$VERSION/" $ROCKSPEC
   - sed -i -e "s/\${TAG}/$GIT_TAG/" $ROCKSPEC
+  - cat $ROCKSPEC
   - source .travis/setenv_lua.sh
   - luarocks install Lua-cURL --server=https://luarocks.org/dev
   - luarocks install lunitx

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     - VERSION=1.2.0-1
     - NAME=lua-resty-openidc
     - ROCKSPEC=$NAME-$VERSION.rockspec
+    - ROCK=$NAME-$VERSION.src.rock
     - LUAROCKS=2.3.0
   matrix:
     - LUA=lua5.1
@@ -22,8 +23,15 @@ before_install:
 
 install:
   - luarocks make $ROCKSPEC CFLAGS="-O2 -fPIC -fprofile-arcs" LIBFLAG="-shared"
-  # TODO: We need to inject the current rock of lua-resty-openidc into the Docker container.
-  #       It will now just fetch the latest one from luarocks.org.
+  - luarocks pack $ROCKSPEC
+  # Remove the last line of the Dockerfile so we can build the Docker image with
+  # our freshly packed Lua rock:
+  - sed -i '$ d' Dockerfile
+  # Append COPY command to get the rock into the Docker container:
+  - echo "COPY ./${ROCK} /" >> Dockerfile
+  # Append RUN command to install the copied rock:
+  - echo "RUN /usr/local/openresty/luajit/bin/luarocks install ${ROCK}" >> Dockerfile
+  - cat Dockerfile
   - docker build -t lua-resty-openidc .
   - docker run -d -p 127.0.0.1:80:80 --name lua-resty-openidc lua-resty-openidc
 
@@ -33,7 +41,6 @@ script:
   # interface of lua-resty-openidc.
 
 after_success:
-  - luarocks pack $ROCKSPEC
   # The API key comes from an environment variable configured on
   # https://travis-ci.org/
   - luarocks upload $ROCKSPEC --api-key=$API_KEY

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
   - VERSION=`git describe | grep -oP '[\d\.]+\-\d+'`
   - ROCKSPEC=$NAME-$VERSION.rockspec
   - ROCK=$NAME-$VERSION.src.rock
+  - echo $ROCKSPEC && echo $ROCK
   - source .travis/setenv_lua.sh
   - luarocks install Lua-cURL --server=https://luarocks.org/dev
   - luarocks install lunitx

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,14 @@ services:
     - docker
 
 before_install:
-  - VERSION=`git describe | grep -oP '[\d\.]+\-\d+'`
-  - ROCKSPEC=$NAME-$VERSION.rockspec
-  - ROCK=$NAME-$VERSION.src.rock
+  - export GIT_TAG=`git describe --abbrev=0`
+  - export VERSION=`git describe | grep -oP '[\d\.]+\-\d+'`
+  - export ROCKSPEC=$NAME-$VERSION.rockspec
+  - export ROCK=$NAME-$VERSION.src.rock
   - echo $ROCKSPEC && echo $ROCK
+  - mv $NAME.rockspec $ROCKSPEC
+  - sed -i -e "s/\${VERSION}/$VERSION/" $ROCKSPEC
+  - sed -i -e "s/\${TAG}/$GIT_TAG/" $ROCKSPEC
   - source .travis/setenv_lua.sh
   - luarocks install Lua-cURL --server=https://luarocks.org/dev
   - luarocks install lunitx

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ install:
   - echo "RUN /usr/local/openresty/luajit/bin/luarocks install ${ROCK}" >> Dockerfile
   - cat Dockerfile
   - docker build -t lua-resty-openidc .
-  - docker run -d -p 127.0.0.1:80:80 --name lua-resty-openidc lua-resty-openidc
 
 script:
+  - docker run -d -p 127.0.0.1:80:80 --name lua-resty-openidc lua-resty-openidc
   - docker ps | grep -q lua-resty-openidc
   # TODO: Add some integration tests that excersice the OAuth and OpenID Connect
   # interface of lua-resty-openidc.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM openresty/openresty:trusty
 
 MAINTAINER Asbjørn Ulsberg <asbjorn@ulsberg.no>
+RUN apt-get install -y libssl-dev
+RUN apt-get install -y git
 RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-openidc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM ficusio/openresty
 
+MAINTAINER Asbjørn Ulsberg <asbjorn@ulsberg.no>
 RUN wget http://luarocks.org/releases/luarocks-2.3.0.tar.gz
 RUN tar zxpf luarocks-2.3.0.tar.gz
 RUN cd luarocks-2.3.0
@@ -10,3 +11,4 @@ RUN luarocks install lua-resty-http
 RUN luarocks install lua-resty-session
 RUN luarocks install lua-resty-jwt
 RUN luarocks install lua-resty-hmac
+RUN luarocks install lua-resty-openidc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ficusio/openresty
+
+RUN wget http://luarocks.org/releases/luarocks-2.3.0.tar.gz
+RUN tar zxpf luarocks-2.3.0.tar.gz
+RUN cd luarocks-2.3.0
+RUN ./configure; sudo make bootstrap
+RUN sudo luarocks install luasocket
+RUN luarocks install lua-resty-http
+RUN luarocks install lua-resty-http
+RUN luarocks install lua-resty-session
+RUN luarocks install lua-resty-jwt
+RUN luarocks install lua-resty-hmac

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,4 @@
 FROM openresty/openresty:trusty
 
 MAINTAINER Asbjørn Ulsberg <asbjorn@ulsberg.no>
-RUN wget http://luarocks.org/releases/luarocks-2.3.0.tar.gz
-RUN tar zxpf luarocks-2.3.0.tar.gz
-RUN cd luarocks-2.3.0
-RUN ./configure; sudo make bootstrap
-RUN sudo luarocks install luasocket
-RUN luarocks install lua-resty-http
-RUN luarocks install lua-resty-http
-RUN luarocks install lua-resty-session
-RUN luarocks install lua-resty-jwt
-RUN luarocks install lua-resty-hmac
-RUN luarocks install lua-resty-openidc
+RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-openidc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ficusio/openresty
+FROM openresty/openresty:trusty
 
 MAINTAINER Asbjørn Ulsberg <asbjorn@ulsberg.no>
 RUN wget http://luarocks.org/releases/luarocks-2.3.0.tar.gz

--- a/lua-resty-openidc.rockspec
+++ b/lua-resty-openidc.rockspec
@@ -1,8 +1,8 @@
 package = "lua-resty-openidc"
-version = "1.2.0-1"
+version = "${VERSION}"
 source = {
     url = "git://github.com/pingidentity/lua-resty-openidc",
-    tag = "v1.2.0"
+    tag = "${TAG}"
 }
 description = {
     summary = "A library for NGINX implementing the OpenID Connect Relying Party (RP) and the OAuth 2.0 Resource Server (RS) functionality",


### PR DESCRIPTION
This PR does a few things, namely:

1. Adds a `Dockerfile` based on [`openresty/openresty:trusty`](https://hub.docker.com/r/openresty/openresty/), which makes it easier to get `lua-resty-openidc` up and running with all dependencies.
2. Removes the need to have a hard coded version number in the Lua `.rockspec` file; the version information is retrieved from `git describe` instead.
3. When a tag is being built, the packed `.rock` file will be uploaded to the repository's release for the given tag.
4. With the release tracking in place, uploading of the `.rock` to Lua Rocks has been moved to `after_deploy`, which means it won't be attempted for all builds; only for tagged ones.

A note to point 3 above: This requires a [personal access token](https://github.com/settings/tokens) to be created and added in [the Travis settings for the repository](https://travis-ci.org/pingidentity/lua-resty-openidc/settings) with the environment variable name `GITHUB_OAUTH_TOKEN`.

What's blatantly missing from this PR are tests to exercise the Docker container's NGINX server with OAuth and OpenID Connect test scenarios. I've added #14 to track this.

I'd also like to add uploading the Docker image to [Docker Hub](https://hub.docker.com/) with [`docker push`](https://docs.docker.com/v1.11/engine/userguide/containers/dockerrepos/#pushing-a-repository-to-docker-hub), but that requires quite a bit of setup on Docker Hub first. I've added #15 to track this.