### PR TITLE
install openidc consistent with README

### DIFF
--- a/lua-resty-openidc-1.2.0-1.rockspec
+++ b/lua-resty-openidc-1.2.0-1.rockspec
@@ -30,6 +30,6 @@ dependencies = {
 build = {
     type = "builtin",
     modules = {
-        openidc = "lib/resty/openidc.lua"
+        ["resty.openidc"] = "lib/resty/openidc.lua"
     }
 }


### PR DESCRIPTION
When I installed this from a rock, require("resty.openidc") did not work. Instead, it was installed as require("openidc"). This change brings it in line with what lua-resty-jwt and lua-resty-http do.