### PR TITLE
Saving encrypted id_token to session data.

### DIFF
--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -341,6 +341,7 @@ local function openidc_authorization_response(opts, session)
   session:start()
   session.data.user = user
   session.data.id_token = id_token
+  session.data.enc_id_token = json.id_token
   session.data.access_token = json.access_token
 
   -- save the session with the obtained id_token


### PR DESCRIPTION
This change allows the jwt id_token to be set on the proxied request.  Kubernetes OIDC integration requires the bearer token be set to the jwt id_token instead of the access_token.