### PR TITLE
Support for prompt parameter during authorization, returning session data, and logout url override

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Chris Lunsford <https://github.com/cllunsford>
 	Iván Perdomo <https://github.com/iperdomo>
 	Robert <https://github.com/p0pr0ck5>
+	Guillaume Destuynder (kang) <https://www.insecure.ws/>

--- a/README.md
+++ b/README.md
@@ -97,9 +97,12 @@ http {
              client_secret = "<client_secret>"
              --authorization_params = { hd="pingidentity.com" },
              --scope = "openid email profile",
+             -- Refresh the user's id_token after 900 seconds without requiring re-authentication
+             --refresh_session_interval = 900,
              --iat_slack = 600,
              --redirect_uri_scheme = "https",
              --logout_path = "/logout",
+             --redirect_after_logout_uri = "/",
              --token_endpoint_auth_method = ["client_secret_basic"|"client_secret_post"],
              --ssl_verify = "no"
           }

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -481,6 +481,8 @@ local function openidc_logout(opts, session)
     ngx.print(openidc_transparent_pixel)
     ngx.exit(ngx.OK)
     return
+  elseif opts.redirect_after_logout_uri then
+    return ngx.redirect(opts.redirect_after_logout_uri)
   elseif opts.discovery.end_session_endpoint then
     return ngx.redirect(opts.discovery.end_session_endpoint)
   elseif opts.discovery.ping_end_session_endpoint then

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -284,28 +284,28 @@ local function openidc_authorization_response(opts, session)
   if not args.code or not args.state then
     err = "unhandled request to the redirect_uri: "..ngx.var.request_uri
     ngx.log(ngx.ERR, err)
-    return nil, err, session.data.original_url
+    return nil, err, session.data.original_url, session
   end
 
   -- check that the state returned in the response against the session; prevents CSRF
   if args.state ~= session.data.state then
     err = "state from argument: "..(args.state and args.state or "nil").." does not match state restored from session: "..(session.data.state and session.data.state or "nil")
     ngx.log(ngx.ERR, err)
-    return nil, err, session.data.original_url
+    return nil, err, session.data.original_url, session
   end
 
   -- check the iss if returned from the OP
   if args.iss and args.iss ~= opts.discovery.issuer then
     err = "iss from argument: "..args.iss.." does not match expected issuer: "..opts.discovery.issuer
     ngx.log(ngx.ERR, err)
-    return nil, err, session.data.original_url
+    return nil, err, session.data.original_url, session
   end
 
   -- check the client_id if returned from the OP
   if args.client_id and args.client_id ~= opts.client_id then
     err = "client_id from argument: "..args.client_id.." does not match expected client_id: "..opts.client_id
     ngx.log(ngx.ERR, err)
-    return nil, err, session.data.original_url
+    return nil, err, session.data.original_url, session
   end
 
   -- assemble the parameters to the token endpoint
@@ -319,7 +319,7 @@ local function openidc_authorization_response(opts, session)
   -- make the call to the token endpoint
   local json, err = openidc_call_token_endpoint(opts, opts.discovery.token_endpoint, body, opts.token_endpoint_auth_method)
   if err then
-    return nil, err, session.data.original_url
+    return nil, err, session.data.original_url, session
   end
 
   -- process the token endpoint response with the id_token and access_token
@@ -330,7 +330,7 @@ local function openidc_authorization_response(opts, session)
   -- validate the id_token contents
   if openidc_validate_id_token(opts, id_token, session.data.nonce) == false then
     err = "id_token validation failed"
-    return nil, err, session.data.original_url
+    return nil, err, session.data.original_url, session
   end
 
   -- call the user info endpoint
@@ -347,7 +347,7 @@ local function openidc_authorization_response(opts, session)
   session:save()
 
   -- redirect to the URL that was accessed originally
-  return ngx.redirect(session.data.original_url)
+  return ngx.redirect(session.data.original_url), session
 
 end
 
@@ -546,7 +546,7 @@ function openidc.authenticate(opts, target_url)
     --end
     opts.discovery, err = openidc_discover(opts.discovery, opts.ssl_verify)
     if err then
-      return nil, err, target_url
+      return nil, err, target_url, session
     end
   end
 
@@ -559,19 +559,19 @@ function openidc.authenticate(opts, target_url)
     if not session.present then
       err = "request to the redirect_uri_path but there's no session state found"
       ngx.log(ngx.ERR, err)
-      return nil, err, target_url
+      return nil, err, target_url, session
     end
-    return openidc_authorization_response(opts, session)
+    return openidc_authorization_response(opts, session), session
   end
 
   -- see if this is a request to logout
   if path == (opts.logout_path and opts.logout_path or "/logout") then
-    return openidc_logout(opts, session)
+    return openidc_logout(opts, session), session
   end
 
   -- if we have no id_token then redirect to the OP for authentication
   if not session.present or not session.data.id_token then
-    return openidc_authorize(opts, session, target_url)
+    return openidc_authorize(opts, session, target_url), session
   end
 
   -- log id_token contents
@@ -585,7 +585,8 @@ function openidc.authenticate(opts, target_url)
       user=session.data.user
     },
     err,
-    target_url
+    target_url,
+    session
 end
 
 -- get an OAuth 2.0 bearer access token from the HTTP request

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -579,12 +579,12 @@ function openidc.authenticate(opts, target_url)
   end
 
   -- silently reauthenticate if necessary (mainly used for session refresh/getting updated id_token data)
-  reauth_delay = opts.refresh_session_interval and opts.refresh_session_interval or 900
-  if session.data.last_authenticated == nil or (session.data.last_authenticated+reauth_delay) < ngx.time() then
-    opts.prompt = "none"
-    return openidc_authorize(opts, session, target_url), session
+  if opts.refresh_session_interval ~= nil then
+    if session.data.last_authenticated == nil or (session.data.last_authenticated+opts.refresh_session_interval) < ngx.time() then
+      opts.prompt = "none"
+      return openidc_authorize(opts, session, target_url), session
+    end
   end
-
 
   -- log id_token contents
   ngx.log(ngx.DEBUG, "id_token=", cjson.encode(session.data.id_token))


### PR DESCRIPTION
Hi,

these are 3 patches that we use at Mozilla (i.e. for Mozilla properties authenticating with OpenID Connect) with OpenID Connect. Let me know if you'd prefer 3 PRs, though some depend on each other.

The prompt parameter allows for silent re authentication in particular in this case (though this can be further extended later to support all options), as seen on http://testrp.security.allizom.org/. This allows to refresh user profile information without login the user out and back in. Spec at http://openid.net/specs/openid-connect-implicit-1_0.html#RequestParameters

The session data being returned allows for the calling code to get full session data (lua-resty-session does not always allow this otherwise)

Finally, the logout URL redirect allows to override the discovered redirect from the OP - or to set one if there was none discovered - particularly helpful when using through an OpenIDConnect access proxy.

Thanks for your consideration