### PR TITLE
Access token renewal on expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ http {
              --redirect_after_logout_uri = "/",
              --token_endpoint_auth_method = ["client_secret_basic"|"client_secret_post"],
              --ssl_verify = "no"
+             --access_token_expires_in = 3600
+             -- Default lifetime in seconds of the access_token if no expires_in attribute is present in the token 
+                endpoint response.
+                This plugin will silently renew the access_token once it's expired if refreshToken scope is present.
+             --access_token_expires_leeway = 0
+                Expiration leeway for access_token renewal.
+                If this is set, renewal will happen access_token_expires_leeway seconds before the token expiration.
+                This avoids errors in case the access_token just expires when arriving to the OAuth Resoource Server.
           }
 
           -- call authenticate for OpenID Connect user authentication


### PR DESCRIPTION
PR  for issue #51 

Hope this PR is fine (this is my first attempt with lua)

Access token renewal when access_token is expired by calling token endpoint with grant_type=refresh_token.
refreshToken must be one of the granted scope for this to happen.

 * API `authenticate`  has been updated
   Whenever the access_token is expired, we renew the access_token if refresh_token exist.
 * API `access_token` has been added
   This API returns a valid access_token (either the existing one if it's not expired, a renewed one if it was expired or nil if there's no access_token or no way to get a valid access_token). 
   This API can be used to map a /api to OAuth protected Resource Servers in case we don't want to trigger authentication on /api.
   We can imagine this kind of usage when Resource Server are called by ajax javascript clients, and the clients don't want to handle redirects due to authentication initiation flow (they'll handle 401 returned by the nginx or the Resource Server themselves).