### PR TITLE
Add support for passing resty.session options

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Robert <https://github.com/p0pr0ck5>
 	Guillaume Destuynder (kang) <https://www.insecure.ws/>
 	gonzalad <https://github.com/gonzalad>
+	Gene Wood <https://github.com/gene1wood>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+05/23/2017
+- add support for passing session options to resty.session; closes #56; thanks @gene1wood
+
 05/18/2017
 - add unauth_action "pass" option to .authenticate(); closes #53; thanks @dholth
 

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -589,11 +589,11 @@ local function openidc_access_token(opts, session)
 end
 
 -- main routine for OpenID Connect user authentication
-function openidc.authenticate(opts, target_url, unauth_action)
+function openidc.authenticate(opts, target_url, unauth_action, session_opts)
 
   local err
 
-  local session = require("resty.session").open()
+  local session = require("resty.session").open(session_opts)
 
   local target_url = target_url or ngx.var.request_uri
 
@@ -672,9 +672,9 @@ function openidc.authenticate(opts, target_url, unauth_action)
 end
 
 -- get a valid access_token (eventually refreshing the token), or nil if there's no valid access_token
-function openidc.access_token(opts)
+function openidc.access_token(opts, session_opts)
 
-  local session = require("resty.session").open()
+  local session = require("resty.session").open(session_opts)
 
   return openidc_access_token(opts, session)
 


### PR DESCRIPTION
Closes #56 

I didn't add anything to the README for this new feature as it didn't look like there was yet a section that calls out how to call the authenticate method.