### PR TITLE
guard call to openidc_discover against repeated use

### DIFF
--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -780,9 +780,11 @@ function openidc.jwt_verify(access_token, opts)
     -- No secret given try getting it from the jwks endpoint
     if not opts.secret and opts.discovery then
       ngx.log(ngx.DEBUG, "bearer_jwt_verify using discovery.")
-      opts.discovery, err = openidc_discover(opts.discovery, opts.ssl_verify)
-      if err then
-        return nil, err
+      if type(opts.discovery) == "string" then
+        opts.discovery, err = openidc_discover(opts.discovery, opts.ssl_verify)
+        if err then
+          return nil, err
+        end
       end
 
       -- We decode the token twice, could be saved


### PR DESCRIPTION
I've got an API where clients can provide an access_token either as a bearer token or using a different channel. Using that I may be calling `openidc.jwt_verify` multiple times using the same options.

The trivial patch adds the same guard to `openidc.jwt_verify` that's already present in `openidc.authenticate`.
