### PR TITLE
add option that forces the auth flow to be executed

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ http {
                 Expiration leeway for access_token renewal.
                 If this is set, renewal will happen access_token_expires_leeway seconds before the token expiration.
                 This avoids errors in case the access_token just expires when arriving to the OAuth Resoource Server.
+             --force_reauthorize = true
           }
 
           -- call authenticate for OpenID Connect user authentication

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -631,7 +631,7 @@ function openidc.authenticate(opts, target_url, unauth_action, session_opts)
   end
 
   -- if we have no id_token then redirect to the OP for authentication
-  if not session.present or not session.data.id_token then
+  if not session.present or not session.data.id_token or opts.force_reauthorize then
     if unauth_action == "pass" then
       return
         nil,


### PR DESCRIPTION
This adds an option to forcefully re-run the code grant flow. My use case is adding additional scopes after a user has already authenticated.