### PR TITLE
make force_reauthorize example use default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ http {
                 Expiration leeway for access_token renewal.
                 If this is set, renewal will happen access_token_expires_leeway seconds before the token expiration.
                 This avoids errors in case the access_token just expires when arriving to the OAuth Resoource Server.
-             --force_reauthorize = true
+             --force_reauthorize = false
+             -- when force_reauthorize is set to true the authorization flow will be executed even if a token has been cached already
           }
 
           -- call authenticate for OpenID Connect user authentication


### PR DESCRIPTION
Fixing example of #65 - see https://github.com/pingidentity/lua-resty-openidc/pull/65#pullrequestreview-41646227