### PR TITLE
fix set cache when pass an invalid token to keycloak

### DIFF
--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -758,15 +758,19 @@ function openidc.introspect(opts)
 
     -- call the introspection endpoint
     json, err = openidc_call_token_endpoint(opts, opts.introspection_endpoint, body, nil)
-
+    
     -- cache the results
     if json then
-      local expiry_claim = opts.expiry_claim or "expires_in"
-      local ttl = json[expiry_claim]
-      if expiry_claim ~= "exp" then --https://tools.ietf.org/html/rfc7662#section-2.2
-        ttl = ttl - ngx.time()
+      if json.active then
+        local expiry_claim = opts.expiry_claim or "expires_in"
+        local ttl = json[expiry_claim]
+        if expiry_claim ~= "exp" then --https://tools.ietf.org/html/rfc7662#section-2.2
+          ttl = ttl - ngx.time()
+        end
+        openidc_cache_set("introspection", access_token, cjson.encode(json), ttl)
+      else
+        err = "token is invaild"
       end
-      openidc_cache_set("introspection", access_token, cjson.encode(json), ttl)
     end
 
   else

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -769,7 +769,7 @@ function openidc.introspect(opts)
         end
         openidc_cache_set("introspection", access_token, cjson.encode(json), ttl)
       else
-        err = "token is invaild"
+        err = "invalid token"
       end
     end
 


### PR DESCRIPTION
I got a error like as blow:
```
 2017/06/30 08:24:01 [error] 7#7: *15 lua entry thread aborted: runtime error: /usr/local/lib/lua/5.1/resty/openidc.lua:69: bad argument #3 to 'set' (number expected, got nil)
```

It's because keycloak return `{"active":false}` when pass a invalid token.