### PR TITLE
Support display parameter

### DIFF
--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -179,11 +179,11 @@ local function openidc_authorize(opts, session, target_url)
     nonce=nonce,
     prompt=opts.prompt and opts.prompt or ""
   }
-  
+
   if opts.display then
-      params.display = opts.display  
+    params.display = opts.display  
   end
-  
+
   -- merge any provided extra parameters
   if opts.authorization_params then
     for k,v in pairs(opts.authorization_params) do params[k] = v end

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -179,7 +179,11 @@ local function openidc_authorize(opts, session, target_url)
     nonce=nonce,
     prompt=opts.prompt and opts.prompt or ""
   }
-
+  
+  if opts.display then
+      params.display = opts.display  
+  end
+  
   -- merge any provided extra parameters
   if opts.authorization_params then
     for k,v in pairs(opts.authorization_params) do params[k] = v end


### PR DESCRIPTION
Adds support for the `display` request parameter in accordance with the [OIDC spec 3.1.2.1](http://openid.net/specs/openid-connect-core-1_0.html#rfc.section.3.1.2.1).