### PR TITLE
Make jwt exp check use slack

### DIFF
--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -935,7 +935,8 @@ function openidc.jwt_verify(access_token, opts, ...)
     -- cache the results
     if json and json.valid == true and json.verified == true then
       json = json.payload
-      openidc_cache_set("introspection", access_token, cjson.encode(json), json.exp - ngx.time())
+      local ttl = json.exp and json.exp - ngx.time() or 120
+      openidc_cache_set("introspection", access_token, cjson.encode(json), ttl)
     else
       err = "invalid token: ".. json.reason
     end

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -897,6 +897,7 @@ function openidc.jwt_verify(access_token, opts, ...)
   local err
   local json
 
+  local slack = opts.iat_slack and opts.iat_slack or 120
   -- see if we've previously cached the validation result for this access token
   local v = openidc_cache_get("introspection", access_token)
   if not v then
@@ -928,6 +929,15 @@ function openidc.jwt_verify(access_token, opts, ...)
       end
     end
 
+    if #{...} == 0 then
+      -- an empty list of claim specs makes lua-resty-jwt add default
+      -- validators for the exp and nbf claims if they are
+      -- present. These validators need to know the configured slack
+      -- value
+      local jwt_validators = require "resty.jwt-validators"
+      jwt_validators.set_system_leeway(slack)
+    end
+
     json = jwt:verify(opts.secret, access_token, ...)
 
     ngx.log(ngx.DEBUG, "jwt: ", cjson.encode(json))
@@ -946,7 +956,6 @@ function openidc.jwt_verify(access_token, opts, ...)
     json = cjson.decode(v)
   end
 
-  local slack=opts.iat_slack and opts.iat_slack or 120
   -- check the token expiry
   if json then
     if json.exp and json.exp + slack < ngx.time() then

--- a/tests/spec/bearer_token_verification_spec.lua
+++ b/tests/spec/bearer_token_verification_spec.lua
@@ -171,14 +171,13 @@ describe("when the access token has expired", function()
   it("the token is invalid", function()
     assert.are.equals(401, status)
   end)
-  --[[ getting error message from lua-resty-jwt rather than our own
   it("an error is logged", function()
-    assert.error_log_contains("JWT expired")
+    -- this is the error message from lua-resty-jwt rather than our
+    -- own as its verification comes first
+    assert.error_log_contains("'exp' claim expired at")
   end)
-  ]]
 end)
 
---[[ will need to configure lua-resty-jwt as well or suppress its "exp" claim spec
 describe("when the access token has expired but slack is big enough", function()
   test_support.start_server({
     verify_opts = {
@@ -196,7 +195,7 @@ describe("when the access token has expired but slack is big enough", function()
     headers = { authorization = "Bearer " .. jwt }
   })
   it("the token is valid", function()
-    assert.are.equals(200, status)
+    assert.are.equals(204, status)
   end)
 end)
-]]
+

--- a/tests/spec/bearer_token_verification_spec.lua
+++ b/tests/spec/bearer_token_verification_spec.lua
@@ -199,3 +199,21 @@ describe("when the access token has expired but slack is big enough", function()
   end)
 end)
 
+describe("when the access token doesn't contain the exp claim at all", function()
+  test_support.start_server({
+    verify_opts = {
+      secret = test_support.load("/spec/public_rsa_key.pem"),
+    },
+    remove_access_token_claims = { "exp" },
+  })
+  teardown(test_support.stop_server)
+  local jwt = test_support.trim(http.request("http://127.0.0.1/jwt"))
+  local _, status = http.request({
+    url = "http://127.0.0.1/verify_bearer_token",
+    headers = { authorization = "Bearer " .. jwt }
+  })
+  it("the token is valid", function()
+    assert.are.equals(204, status)
+  end)
+end)
+

--- a/tests/spec/test_support.lua
+++ b/tests/spec/test_support.lua
@@ -192,6 +192,9 @@ local function write_config(out, custom_config)
   for _, k in ipairs(custom_config["remove_id_token_claims"] or {}) do
     id_token[k] = nil
   end
+  for _, k in ipairs(custom_config["remove_access_token_claims"] or {}) do
+    access_token[k] = nil
+  end
   local config = DEFAULT_CONFIG_TEMPLATE
     :gsub("OIDC_CONFIG", serpent.block(oidc_config, {comment = false }))
     :gsub("ID_TOKEN", serpent.block(id_token, {comment = false }))
@@ -213,6 +216,7 @@ end
 -- - jwt_verify_secret the secret to use when verifying the secret
 -- - access_token is a table containing claims for the access token provided by /jwt
 -- - access_token_header is a table containing claims for the header used by /jwt
+-- - remove_access_token_claims is an array of claims to remove from the access_token
 -- - jwk the JWK keystore to provide
 function test_support.start_server(custom_config)
   assert(os.execute("rm -rf /tmp/server"), "failed to remove old server dir")


### PR DESCRIPTION
if you don't specify any custom "claim specs" lua-resty-jwt will add verifications for the `exp` and `nbf` claims if the JWT contains them[1][2]. These checks need to know about the configured slack value as lua-resty-jwt 's default is a slack of 0[3].

I also fixed an error for the case where the access token doesn't contain any `exp` claim at all.

[1] https://github.com/SkyLothar/lua-resty-jwt/blob/master/lib/resty/jwt.lua#L680
[2] https://github.com/SkyLothar/lua-resty-jwt/blob/master/lib/resty/jwt.lua#L359
[3] https://github.com/SkyLothar/lua-resty-jwt/blob/master/lib/resty/jwt-validators.lua#L320