### PR TITLE
Differentiate rsa keys

### DIFF
--- a/tests/spec/bearer_token_verification_spec.lua
+++ b/tests/spec/bearer_token_verification_spec.lua
@@ -159,7 +159,7 @@ describe("when the JWK specifies no kid and the JWKS contains multiple keys", fu
     assert.are.equals(401, status)
   end)
   it("an error is logged", function()
-    assert.error_log_contains("JWT doesn't specify kid but the keystore contains multiple keys")
+    assert.error_log_contains("JWT doesn't specify kid but the keystore contains multiple RSA keys")
   end)
 end)
 


### PR DESCRIPTION
search explicitly for RSA keys as that's the only type of key that we support today; this way other keys won't get in the way in case a JWT was provided with no kid: if there's only one RSA (signing) key amongst the set we can still assume that's the one we need