### PR TITLE
ensure id_token_hint uses correct separator on logout

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+10/27/2017
+- ensured id_token_hint uses the correct query string separator when
+  opts.redirect_after_logout_uri is used together with redirect_after_logout_with_id_token_hint
+
 10/24/2017
 - verify RSA signatures on JWTs (id_token/access_token); thanks @venkatmarepalli
 - rely on lua-resty-jwt validators for id_token and/or JWT access_token validation

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -773,7 +773,11 @@ local function openidc_logout(opts, session)
     ngx.exit(ngx.OK)
     return
   elseif opts.redirect_after_logout_uri and opts.redirect_after_logout_with_id_token_hint then
-    return ngx.redirect(opts.redirect_after_logout_uri.."&id_token_hint="..session_token)
+    local sep = "?"
+    if string.find(opts.redirect_after_logout_uri, "?", 1, true) then
+      sep = "&"
+    end
+    return ngx.redirect(opts.redirect_after_logout_uri..sep..ngx.encode_args({id_token_hint=session_token}))
   elseif opts.redirect_after_logout_uri then
     return ngx.redirect(opts.redirect_after_logout_uri)
   elseif opts.discovery.end_session_endpoint then

--- a/tests/spec/logout_spec.lua
+++ b/tests/spec/logout_spec.lua
@@ -71,9 +71,39 @@ describe("when logout is invoked and a callback with hint has been configured", 
     assert.are.equals(302, status)
     assert.truthy(string.match(headers["location"], "http://127.0.0.1/after%-logout.*"))
   end)
-  -- TODO fix parameter handling, currently separator always is an ampersand
   it("the redirect contains the id_token_hint", function()
-    assert.truthy(string.match(headers["location"], ".*id_token_hint=.*"))
+    assert.truthy(string.match(headers["location"], ".*%?id_token_hint=.*"))
+  end)
+  it("the session cookie has been revoked", function()
+    assert.truthy(string.match(headers["set-cookie"],
+                               "session=; Expires=Thu, 01 Jan 1970 00:00:01 GMT.*"))
+  end)
+end)
+
+describe("when logout is invoked and a callback with hint has been configured - callback contains question mark", function()
+  test_support.start_server({
+      oidc_opts = {
+        discovery = {
+          end_session_endpoint = "http://127.0.0.1/end-session",
+          ping_end_session_endpoint = "http://127.0.0.1/ping-end-session",
+        },
+        redirect_after_logout_uri = "http://127.0.0.1/after-logout?foo=bar",
+        redirect_after_logout_with_id_token_hint = true,
+      }
+  })
+  teardown(test_support.stop_server)
+  local _, _, cookie = test_support.login()
+  local _, status, headers = http.request({
+      url = "http://127.0.0.1/default/logout",
+      headers = { cookie = cookie },
+      redirect = false
+  })
+  it("the response redirects to the callback", function()
+    assert.are.equals(302, status)
+    assert.truthy(string.match(headers["location"], "http://127.0.0.1/after%-logout%?foo=bar.*"))
+  end)
+  it("the redirect contains the id_token_hint", function()
+    assert.truthy(string.match(headers["location"], ".*%&id_token_hint=.*"))
   end)
   it("the session cookie has been revoked", function()
     assert.truthy(string.match(headers["set-cookie"],


### PR DESCRIPTION
currently the `id_token_hint` parameter is added to `opts.redirect_after_logout_uri` separated by a `&` unconditionally.