### PR TITLE
add id_token_hint to end_session_endpoint

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+10/28/2017
+- add id_token_hint when calling end_session_endpoint
+
 10/27/2017
 - ensured id_token_hint uses the correct query string separator when
   opts.redirect_after_logout_uri is used together with redirect_after_logout_with_id_token_hint

--- a/tests/spec/logout_spec.lua
+++ b/tests/spec/logout_spec.lua
@@ -111,6 +111,40 @@ describe("when logout is invoked and a callback with hint has been configured - 
   end)
 end)
 
+describe("when logout is invoked and a callback with hint has been configured but id_token hasn't been cached", function()
+  test_support.start_server({
+      oidc_opts = {
+        discovery = {
+          end_session_endpoint = "http://127.0.0.1/end-session",
+          ping_end_session_endpoint = "http://127.0.0.1/ping-end-session",
+        },
+        redirect_after_logout_uri = "http://127.0.0.1/after-logout",
+        redirect_after_logout_with_id_token_hint = true,
+        session_contents = {
+          access_token = true
+        }
+      }
+  })
+  teardown(test_support.stop_server)
+  local _, _, cookie = test_support.login()
+  local _, status, headers = http.request({
+      url = "http://127.0.0.1/default/logout",
+      headers = { cookie = cookie },
+      redirect = false
+  })
+  it("the response redirects to the callback", function()
+    assert.are.equals(302, status)
+    assert.truthy(string.match(headers["location"], "http://127.0.0.1/after%-logout.*"))
+  end)
+  it("the redirect doesn't contain the id_token_hint", function()
+    assert.falsy(string.match(headers["location"], ".*id_token_hint=.*"))
+  end)
+  it("the session cookie has been revoked", function()
+    assert.truthy(string.match(headers["set-cookie"],
+                               "session=; Expires=Thu, 01 Jan 1970 00:00:01 GMT.*"))
+  end)
+end)
+
 describe("when logout is invoked and a callback without hint has been configured", function()
   test_support.start_server({
       oidc_opts = {
@@ -141,7 +175,7 @@ describe("when logout is invoked and a callback without hint has been configured
   end)
 end)
 
-describe("when logout is invoked and discovery contains end_session_endpoint", function()
+describe("when logout is invoked and discovery contains end_session_endpoint and the id_token has been cached", function()
   test_support.start_server({
       oidc_opts = {
         discovery = {
@@ -160,6 +194,41 @@ describe("when logout is invoked and discovery contains end_session_endpoint", f
   it("the response redirects to the callback", function()
     assert.are.equals(302, status)
     assert.truthy(string.match(headers["location"], "http://127.0.0.1/end%-session.*"))
+  end)
+  it("the redirect contains the id_token_hint", function()
+    assert.truthy(string.match(headers["location"], ".*%id_token_hint=.*"))
+  end)
+  it("the session cookie has been revoked", function()
+    assert.truthy(string.match(headers["set-cookie"],
+                               "session=; Expires=Thu, 01 Jan 1970 00:00:01 GMT.*"))
+  end)
+end)
+
+describe("when logout is invoked and discovery contains end_session_endpoint and the id_token hasn't been cached", function()
+  test_support.start_server({
+      oidc_opts = {
+        discovery = {
+          end_session_endpoint = "http://127.0.0.1/end-session",
+          ping_end_session_endpoint = "http://127.0.0.1/ping-end-session",
+        },
+        session_contents = {
+          access_token = true
+        }
+      }
+  })
+  teardown(test_support.stop_server)
+  local _, _, cookie = test_support.login()
+  local _, status, headers = http.request({
+      url = "http://127.0.0.1/default/logout",
+      headers = { cookie = cookie },
+      redirect = false
+  })
+  it("the response redirects to the callback", function()
+    assert.are.equals(302, status)
+    assert.truthy(string.match(headers["location"], "http://127.0.0.1/end%-session.*"))
+  end)
+  it("the redirect contains the id_token_hint", function()
+    assert.falsy(string.match(headers["location"], ".*%id_token_hint=.*"))
   end)
   it("the session cookie has been revoked", function()
     assert.truthy(string.match(headers["set-cookie"],


### PR DESCRIPTION
if the id_token has been cached, that is. Also fixes the case for
redirect_after_logout_uri if caching of the id_token has been
disabled.