### PR TITLE
Improve json error handling

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+11/01/2017
+- now uses cjson.safe when decoding JSON received from external sources for improved error handling
+
 10/30/2017
 - fixed case where openidc.introspect would accept invalid tokens if they contained an exp claim
 

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -49,6 +49,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 local require = require
 local cjson   = require "cjson"
+local cjson_s = require "cjson.safe"
 local http    = require "resty.http"
 local jwt     = require "resty.jwt"
 local string  = string
@@ -249,7 +250,7 @@ local function openidc_parse_json_response(response)
     err = "response indicates failure, status="..response.status..", body="..response.body
   else
     -- decode the response and extract the JSON object
-    res = cjson.decode(response.body)
+    res = cjson_s.decode(response.body)
 
     if not res then
       err = "JSON decoding failed"

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -261,8 +261,9 @@ local function openidc_parse_json_response(response)
 end
 
 -- make a call to the token endpoint
-local function openidc_call_token_endpoint(opts, endpoint, body, auth)
+local function openidc_call_token_endpoint(opts, endpoint, body, auth, endpoint_name)
 
+  local ep_name = endpoint_name or 'token'
   local headers = {
       ["Content-Type"] = "application/x-www-form-urlencoded"
   }
@@ -279,7 +280,7 @@ local function openidc_call_token_endpoint(opts, endpoint, body, auth)
     end
   end
 
-  ngx.log(ngx.DEBUG, "request body for token endpoint call: ", ngx.encode_args(body))
+  ngx.log(ngx.DEBUG, "request body for "..ep_name.." endpoint call: ", ngx.encode_args(body))
 
   local httpc = http.new()
   local res, err = httpc:request_uri(endpoint, {
@@ -289,12 +290,12 @@ local function openidc_call_token_endpoint(opts, endpoint, body, auth)
     ssl_verify = (opts.ssl_verify ~= "no")
   })
   if not res then
-    err = "accessing token endpoint ("..endpoint..") failed: "..err
+    err = "accessing "..ep_name.." endpoint ("..endpoint..") failed: "..err
     ngx.log(ngx.ERR, err)
     return nil, err
   end
 
-  ngx.log(ngx.DEBUG, "token endpoint response: ", res.body)
+  ngx.log(ngx.DEBUG, ep_name.." endpoint response: ", res.body)
 
   return openidc_parse_json_response(res)
 end
@@ -317,8 +318,7 @@ local function openidc_call_userinfo_endpoint(opts, access_token)
     headers = headers
   })
   if not res then
-    err = "accessing userinfo endpoint ("..opts.discovery.userinfo_endpoint..") failed: "..err
-    ngx.log(ngx.ERR, err)
+    err = "accessing ("..opts.discovery.userinfo_endpoint..") failed: "..err
     return nil, err
   end
 
@@ -727,7 +727,9 @@ local function openidc_authorization_response(opts, session)
     local user
     user, err = openidc_call_userinfo_endpoint(opts, json.access_token)
 
-    if user then
+    if err then
+      ngx.log(ngx.ERR, "error calling userinfo endpoint: " .. err)
+    elseif user then
       if id_token.sub ~= user.sub then
         err = "\"sub\" claim in id_token (\"" .. (id_token.sub or "null") .. "\") is not equal to the \"sub\" claim returned from the userinfo endpoint (\"" .. (user.sub or "null") .. "\")"
         ngx.log(ngx.ERR, err)
@@ -1059,7 +1061,7 @@ function openidc.introspect(opts)
     end
 
     -- call the introspection endpoint
-    json, err = openidc_call_token_endpoint(opts, opts.introspection_endpoint, body, nil)
+    json, err = openidc_call_token_endpoint(opts, opts.introspection_endpoint, body, nil, "introspection")
 
     -- cache the results
     if json then

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -378,7 +378,7 @@ local function openidc_discover(url, ssl_verify)
           json = nil
         end
       else
-        err = "could not decode JSON from Discovery data"
+        err = "could not decode JSON from Discovery data" .. (err and (": " .. err) or '')
         ngx.log(ngx.ERR, err)
       end
     end

--- a/tests/spec/access_token_access_spec.lua
+++ b/tests/spec/access_token_access_spec.lua
@@ -220,7 +220,6 @@ describe("when token endpoint sends a 4xx status", function()
   end)
 end)
 
---[[ TODO: cjson.decode throws an error, we lack proper error handling here
 describe("when token endpoint doesn't return proper JSON", function()
   test_support.start_server({
     access_token_opts = {
@@ -242,7 +241,6 @@ describe("when token endpoint doesn't return proper JSON", function()
     assert.are.equals(401, status)
   end)
   it("an error has been logged", function()
-    assert.error_log_contains("access_token error: ")
+    assert.error_log_contains("access_token error: JSON decoding failed")
   end)
 end)
-]]

--- a/tests/spec/bearer_token_verification_spec.lua
+++ b/tests/spec/bearer_token_verification_spec.lua
@@ -331,11 +331,10 @@ describe("when jwks endpoint sends a 4xx status", function()
     assert.are.equals(401, status)
   end)
   it("an error has been logged", function()
-    assert.error_log_contains(".*response indicates failure, status=404,")
+    assert.error_log_contains("Invalid token:.*response indicates failure, status=404,")
   end)
 end)
 
---[[ TODO: cjson.decode throws an error, we lack proper error handling here
 describe("when jwks endpoint doesn't return proper JSON", function()
   test_support.start_server({
     verify_opts = {
@@ -354,7 +353,6 @@ describe("when jwks endpoint doesn't return proper JSON", function()
     assert.are.equals(401, status)
   end)
   it("an error has been logged", function()
-    assert.error_log_contains("access_token error: ")
+    assert.error_log_contains("Invalid token: JSON decoding failed")
   end)
 end)
-]]

--- a/tests/spec/introspection_spec.lua
+++ b/tests/spec/introspection_spec.lua
@@ -139,7 +139,6 @@ describe("when introspection endpoint is not resolvable", function()
     assert.are.equals(401, status)
   end)
   it("an error has been logged", function()
-    -- TODO fix error message, talks about "token endpoint"
     assert.error_log_contains("Introspection error:.*foo.example.org could not be resolved.*")
   end)
 end)
@@ -160,8 +159,7 @@ describe("when introspection endpoint is not reachable", function()
     assert.are.equals(401, status)
   end)
   it("an error has been logged", function()
-    -- TODO fix error message
-    assert.error_log_contains("Introspection error:.*accessing token endpoint %(http://192.0.2.1/%) failed")
+    assert.error_log_contains("Introspection error:.*accessing introspection endpoint %(http://192.0.2.1/%) failed")
   end)
 end)
 

--- a/tests/spec/introspection_spec.lua
+++ b/tests/spec/introspection_spec.lua
@@ -161,7 +161,7 @@ describe("when introspection endpoint is not reachable", function()
   end)
   it("an error has been logged", function()
     -- TODO fix error message
-    assert.error_log_contains(".*accessing token endpoint %(http://192.0.2.1/%) failed")
+    assert.error_log_contains("Introspection error:.*accessing token endpoint %(http://192.0.2.1/%) failed")
   end)
 end)
 
@@ -181,11 +181,10 @@ describe("when introspection endpoint sends a 4xx status", function()
     assert.are.equals(401, status)
   end)
   it("an error has been logged", function()
-    assert.error_log_contains(".*response indicates failure, status=404,")
+    assert.error_log_contains("Introspection error:.*response indicates failure, status=404,")
   end)
 end)
 
---[[ TODO: cjson.decode throws an error, we lack proper error handling here
 describe("when introspection endpoint doesn't return proper JSON", function()
   test_support.start_server({
     introspection_opts = {
@@ -202,7 +201,6 @@ describe("when introspection endpoint doesn't return proper JSON", function()
     assert.are.equals(401, status)
   end)
   it("an error has been logged", function()
-    assert.error_log_contains("access_token error: ")
+    assert.error_log_contains("Introspection error: JSON decoding failed")
   end)
 end)
-]]

--- a/tests/spec/redirect_to_op_spec.lua
+++ b/tests/spec/redirect_to_op_spec.lua
@@ -164,12 +164,11 @@ describe("when discovery endpoint sends a 4xx status", function()
   end)
   --[[ TODO don't swallow error message from openidc_parse_json_response in openidc_discover
   it("an error has been logged", function()
-    assert.error_log_contains(".*response indicates failure, status=404,")
+    assert.error_log_contains("authenticate failed:.*response indicates failure, status=404,")
   end)
   ]]
 end)
 
---[[ TODO: cjson.decode throws an error, we lack proper error handling here
 describe("when discovery endpoint doesn't return proper JSON", function()
   test_support.start_server({
     oidc_opts = {
@@ -184,8 +183,10 @@ describe("when discovery endpoint doesn't return proper JSON", function()
   it("the response is invalid", function()
     assert.are.equals(401, status)
   end)
+  --[[ TODO don't swallow error message from openidc_parse_json_response in openidc_discover
   it("an error has been logged", function()
-    assert.error_log_contains("access_token error: ")
+    assert.error_log_contains("authenticate failed: JSON decoding failed")
   end)
+  ]]
 end)
-]]
+

--- a/tests/spec/redirect_to_op_spec.lua
+++ b/tests/spec/redirect_to_op_spec.lua
@@ -162,11 +162,9 @@ describe("when discovery endpoint sends a 4xx status", function()
   it("the response is invalid", function()
     assert.are.equals(401, status)
   end)
-  --[[ TODO don't swallow error message from openidc_parse_json_response in openidc_discover
   it("an error has been logged", function()
     assert.error_log_contains("authenticate failed:.*response indicates failure, status=404,")
   end)
-  ]]
 end)
 
 describe("when discovery endpoint doesn't return proper JSON", function()
@@ -183,10 +181,8 @@ describe("when discovery endpoint doesn't return proper JSON", function()
   it("the response is invalid", function()
     assert.are.equals(401, status)
   end)
-  --[[ TODO don't swallow error message from openidc_parse_json_response in openidc_discover
   it("an error has been logged", function()
-    assert.error_log_contains("authenticate failed: JSON decoding failed")
+    assert.error_log_contains("authenticate failed:.*JSON decoding failed")
   end)
-  ]]
 end)
 

--- a/tests/spec/token_request_spec.lua
+++ b/tests/spec/token_request_spec.lua
@@ -138,7 +138,6 @@ describe("if token endpoint sends a 4xx status", function()
   end)
 end)
 
---[[ TODO: cjson.decode throws an error, we lack proper error handling here
 describe("if token endpoint doesn't return proper JSON", function()
   test_support.start_server({
     oidc_opts = {
@@ -153,7 +152,6 @@ describe("if token endpoint doesn't return proper JSON", function()
     assert.are.equals(401, status)
   end)
   it("an error has been logged", function()
-    assert.error_log_contains("access_token error: ")
+    assert.error_log_contains("authenticate failed: JSON decoding failed")
   end)
 end)
-]]

--- a/tests/spec/userinfo_spec.lua
+++ b/tests/spec/userinfo_spec.lua
@@ -108,7 +108,6 @@ describe("when userinfo endpoint sends a 4xx status", function()
   ]]
 end)
 
---[[ TODO: cjson.decode throws an error, we lack proper error handling here
 describe("when userinfo endpoint doesn't return proper JSON", function()
   test_support.start_server({
     oidc_opts = {
@@ -122,8 +121,9 @@ describe("when userinfo endpoint doesn't return proper JSON", function()
   it("login succeeds", function()
     assert.are.equals(302, status)
   end)
+  --[[ TODO check error of openidc_parse_json_response in openidc_call_userinfo_endpoint and act on it
   it("an error has been logged", function()
-    assert.error_log_contains("access_token error: ")
+    assert.error_log_contains("JSON decoding failed")
   end)
+  ]]
 end)
-]]

--- a/tests/spec/userinfo_spec.lua
+++ b/tests/spec/userinfo_spec.lua
@@ -84,7 +84,7 @@ describe("when userinfo endpoint is not reachable", function()
     assert.are.equals(302, status)
   end)
   it("an error has been logged", function()
-    assert.error_log_contains(".*accessing userinfo endpoint %(http://192.0.2.1/%) failed")
+    assert.error_log_contains(".*error calling userinfo endpoint: accessing %(http://192.0.2.1/%) failed")
   end)
 end)
 
@@ -101,11 +101,9 @@ describe("when userinfo endpoint sends a 4xx status", function()
   it("login succeeds", function()
     assert.are.equals(302, status)
   end)
-  --[[ TODO check error of openidc_parse_json_response in openidc_call_userinfo_endpoint and act on it
   it("an error has been logged", function()
     assert.error_log_contains(".*response indicates failure, status=404,")
   end)
-  ]]
 end)
 
 describe("when userinfo endpoint doesn't return proper JSON", function()
@@ -121,9 +119,7 @@ describe("when userinfo endpoint doesn't return proper JSON", function()
   it("login succeeds", function()
     assert.are.equals(302, status)
   end)
-  --[[ TODO check error of openidc_parse_json_response in openidc_call_userinfo_endpoint and act on it
   it("an error has been logged", function()
     assert.error_log_contains("JSON decoding failed")
   end)
-  ]]
 end)


### PR DESCRIPTION
This PR contains some improvements to error logging but most importantly it uses `cjson.safe` when parsing the endpoints' JSON responses. Our code expects `decode` to return `nil` on errors which is exactly what `cjson.safe` does, but `cjson` raises an error instead.

The change assumes we'll find cjson 2.1.0 (released in 2012) - if this is not acceptable, I can rework the change to use `pcall` instead.