### PR TITLE
add configurable timeouts for http calls

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+11/06/2017
+- added support for configurable network timeouts
+
 11/01/2017
 - now uses cjson.safe when decoding JSON received from external sources for improved error handling
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ http {
              -- When not set everything will be included in the session.
              -- Available are: 
              -- id_token, enc_id_token, user, access_token (includes refresh token)
+
+             -- You can specify timeouts for connect/send/read as a single number (setting all timeouts) or as a table. Values are in milliseconds
+             -- timeout = 1000
+             -- timeout = { connect = 500, send = 1000, read = 1000 }
           }
 
           -- call authenticate for OpenID Connect user authentication

--- a/tests/spec/bearer_token_verification_spec.lua
+++ b/tests/spec/bearer_token_verification_spec.lua
@@ -313,6 +313,74 @@ describe("when jwks endpoint is not reachable", function()
   end)
 end)
 
+describe("when jwk endpoint is slow but no timeout is configured", function()
+  test_support.start_server({
+    delay_response = { jwk = 1000 },
+    verify_opts = {
+      discovery = {
+        jwks_uri = "http://127.0.0.1/jwk",
+      }
+    }
+  })
+  teardown(test_support.stop_server)
+  local jwt = test_support.trim(http.request("http://127.0.0.1/jwt"))
+  local _, status = http.request({
+    url = "http://127.0.0.1/verify_bearer_token",
+    headers = { authorization = "Bearer " .. jwt }
+  })
+  it("the response is valid", function()
+    assert.are.equals(204, status)
+  end)
+end)
+
+describe("when jwk endpoint is slow and a simple timeout is configured", function()
+  test_support.start_server({
+    delay_response = { jwk = 1000 },
+    verify_opts = {
+      discovery = {
+        jwks_uri = "http://127.0.0.1/jwk",
+      },
+      timeout = 200,
+    },
+  })
+  teardown(test_support.stop_server)
+  local jwt = test_support.trim(http.request("http://127.0.0.1/jwt"))
+  local _, status = http.request({
+    url = "http://127.0.0.1/verify_bearer_token",
+    headers = { authorization = "Bearer " .. jwt }
+  })
+  it("the response is invalid", function()
+    assert.are.equals(401, status)
+  end)
+  it("an error has been logged", function()
+    assert.error_log_contains("Invalid token: accessing jwks url.*%(http://127.0.0.1/jwk%) failed: timeout")
+  end)
+end)
+
+describe("when jwk endpoint is slow and a table timeout is configured", function()
+  test_support.start_server({
+    delay_response = { jwk = 1000 },
+    verify_opts = {
+      discovery = {
+        jwks_uri = "http://127.0.0.1/jwk",
+      },
+      timeout = { read = 200 },
+    },
+  })
+  teardown(test_support.stop_server)
+  local jwt = test_support.trim(http.request("http://127.0.0.1/jwt"))
+  local _, status = http.request({
+    url = "http://127.0.0.1/verify_bearer_token",
+    headers = { authorization = "Bearer " .. jwt }
+  })
+  it("the response is invalid", function()
+    assert.are.equals(401, status)
+  end)
+  it("an error has been logged", function()
+    assert.error_log_contains("Invalid token: accessing jwks url.*%(http://127.0.0.1/jwk%) failed: timeout")
+  end)
+end)
+
 describe("when jwks endpoint sends a 4xx status", function()
   test_support.start_server({
     verify_opts = {

--- a/tests/spec/userinfo_spec.lua
+++ b/tests/spec/userinfo_spec.lua
@@ -88,6 +88,51 @@ describe("when userinfo endpoint is not reachable", function()
   end)
 end)
 
+describe("when userinfo endpoint is slow but no timeout is configured", function()
+  test_support.start_server({
+    delay_response = { userinfo = 1000 },
+  })
+  teardown(test_support.stop_server)
+  local _, status = test_support.login()
+  it("login succeeds", function()
+    assert.are.equals(302, status)
+  end)
+end)
+
+describe("when userinfo endpoint is slow and a simple timeout is configured", function()
+  test_support.start_server({
+    delay_response = { userinfo = 1000 },
+    oidc_opts = {
+      timeout = 200
+    }
+  })
+  teardown(test_support.stop_server)
+  local _, status = test_support.login()
+  it("login succeeds", function()
+    assert.are.equals(302, status)
+  end)
+  it("an error has been logged", function()
+    assert.error_log_contains(".*error calling userinfo endpoint: accessing %(http://127.0.0.1/user%-info%) failed: timeout")
+  end)
+end)
+
+describe("when userinfo endpoint is slow and a table timeout is configured", function()
+  test_support.start_server({
+    delay_response = { userinfo = 1000 },
+    oidc_opts = {
+      timeout = { read = 200 }
+    }
+  })
+  teardown(test_support.stop_server)
+  local _, status = test_support.login()
+  it("login succeeds", function()
+    assert.are.equals(302, status)
+  end)
+  it("an error has been logged", function()
+    assert.error_log_contains(".*error calling userinfo endpoint: accessing %(http://127.0.0.1/user%-info%) failed: timeout")
+  end)
+end)
+
 describe("when userinfo endpoint sends a 4xx status", function()
   test_support.start_server({
     oidc_opts = {


### PR DESCRIPTION
I'm not really sure whether the extra convenience of `timeout=1000` is really needed of the table version, but wanted to mirror the options available for lua-resty-http.