### PR TITLE
let user re-authenticate if we know the access token has expired

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+11/13/2017
+- provided explicit control over whether the access token gets renewed
+  on expiry. If refresh fails, the user is redirected to the OP's
+  authorization endpoint.
+
 11/06/2017
 - added support for configurable network timeouts
 

--- a/README.md
+++ b/README.md
@@ -108,9 +108,12 @@ http {
              --redirect_after_logout_with_id_token_hint = true,
              --token_endpoint_auth_method = ["client_secret_basic"|"client_secret_post"],
              --ssl_verify = "no"
+
+             --renew_access_token_on_expiry = true
+             -- whether this plugin shall try to silently renew the access token once it is expired if a refresh token is available.
+             -- if it fails to renew the token, the user will be redirected to the authorization endpoint.
              --access_token_expires_in = 3600
              -- Default lifetime in seconds of the access_token if no expires_in attribute is present in the token endpoint response. 
-             -- This plugin will silently renew the access_token once it is expired if refreshToken scope is present.
 
              --access_token_expires_leeway = 0
              --  Expiration leeway for access_token renewal. If this is set, renewal will happen access_token_expires_leeway seconds before the token expiration. This avoids errors in case the access_token just expires when arriving to the OAuth Resource Server.

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -953,7 +953,10 @@ function openidc.authenticate(opts, target_url, unauth_action, session_opts)
   end
 
   local token_expired = false
-  if session.present and session.data.authenticated and store_in_session(opts, 'access_token') then
+  local try_to_renew = opts.renew_access_token_on_expiry == nil or opts.renew_access_token_on_expiry
+  if try_to_renew and session.present and session.data.authenticated
+    and store_in_session(opts, 'access_token')
+  then
     -- refresh access_token if necessary
     access_token, err = openidc_access_token(opts, session)
     if err then
@@ -970,7 +973,7 @@ function openidc.authenticate(opts, target_url, unauth_action, session_opts)
   if not session.present
     or not (session.data.id_token or session.data.authenticated)
     or opts.force_reauthorize
-    or token_expired
+    or (try_to_renew and token_expired)
   then
     if unauth_action == "pass" then
       return

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -875,7 +875,7 @@ local function openidc_access_token(opts, session)
     return session.data.access_token, err
   end
   if session.data.refresh_token == nil then
-    return nil, err
+    return nil, "token expired and no refresh token available"
   end
 
   ngx.log(ngx.DEBUG, "refreshing expired access_token: ", session.data.access_token, " with: ", session.data.refresh_token)
@@ -952,9 +952,26 @@ function openidc.authenticate(opts, target_url, unauth_action, session_opts)
     return nil, nil, target_url, session
   end
 
+  local token_expired = false
+  if session.present and session.data.authenticated and store_in_session(opts, 'access_token') then
+    -- refresh access_token if necessary
+    access_token, err = openidc_access_token(opts, session)
+    if err then
+      ngx.log(ngx.ERR, "lost access token:" .. err)
+      err = nil
+    end
+    if not access_token then
+      token_expired = true
+    end
+  end
+
   -- if we are not authenticated then redirect to the OP for authentication
   -- the presence of the id_token is check for backwards compatibility
-  if not session.present or not (session.data.id_token or session.data.authenticated) or opts.force_reauthorize then
+  if not session.present
+    or not (session.data.id_token or session.data.authenticated)
+    or opts.force_reauthorize
+    or token_expired
+  then
     if unauth_action == "pass" then
       return
         nil,
@@ -972,14 +989,6 @@ function openidc.authenticate(opts, target_url, unauth_action, session_opts)
       opts.prompt = "none"
       openidc_authorize(opts, session, target_url)
       return nil, nil, target_url, session
-    end
-  end
-
-  if store_in_session(opts, 'access_token') then
-    -- refresh access_token if necessary
-    access_token, err = openidc_access_token(opts, session)
-    if err then
-      return nil, err, target_url, session
     end
   end
 

--- a/tests/spec/token_refresh_spec.lua
+++ b/tests/spec/token_refresh_spec.lua
@@ -1,0 +1,75 @@
+local http = require("socket.http")
+local test_support = require("test_support")
+require 'busted.runner'()
+
+describe("if there is an active non-expired login", function()
+  test_support.start_server()
+  teardown(test_support.stop_server)
+  local _, _, cookies = test_support.login()
+  local _, status = http.request({
+    url = "http://localhost/default/t",
+    redirect = false,
+    headers = { cookie = cookies },
+  })
+  it("no redirect occurs on the next call", function()
+    assert.are.equals(200, status)
+  end)
+end)
+
+describe("if there is an active but expired login", function()
+  test_support.start_server({
+    token_response_expires_in = 0
+  })
+  teardown(test_support.stop_server)
+  local _, _, cookies = test_support.login()
+  os.execute("sleep 1.5")
+  local _, status = http.request({
+    url = "http://localhost/default/t",
+    redirect = false,
+    headers = { cookie = cookies },
+  })
+  it("no redirect occurs on the next call", function()
+    assert.are.equals(200, status)
+  end)
+  it("the token gets refreshed", function()
+    assert.error_log_contains("request body for token endpoint call: .*grant_type=refresh_token.*")
+  end)
+end)
+
+describe("if there is an active but expired login and no refresh token", function()
+  test_support.start_server({
+    token_response_expires_in = 0,
+    token_response_contains_refresh_token = "false"
+  })
+  teardown(test_support.stop_server)
+  local _, _, cookies = test_support.login()
+  os.execute("sleep 1.5")
+  local _, status = http.request({
+    url = "http://localhost/default/t",
+    redirect = false,
+    headers = { cookie = cookies },
+  })
+  it("a redirect occurs on the next call", function()
+    assert.are.equals(302, status)
+  end)
+end)
+
+-- https://github.com/pingidentity/lua-resty-openidc/issues/117
+describe("if there is an active but expired login and refreshing it fails", function()
+  test_support.start_server({
+    token_response_expires_in = 0,
+    refreshing_token_fails = "true",
+  })
+  teardown(test_support.stop_server)
+  local _, _, cookies = test_support.login()
+  os.execute("sleep 1.5")
+  local _, status = http.request({
+    url = "http://localhost/default/t",
+    redirect = false,
+    headers = { cookie = cookies },
+  })
+  it("a redirect occurs on the next call", function()
+    assert.are.equals(302, status)
+  end)
+end)
+


### PR DESCRIPTION
closes #117 

With this patch if we know the token is expired and we fail to refresh it the user will be sent to the authorization endpoint.

While looking through the code I realized that if we know the user has authenticated once (`session.data.authenticated` is true) but don't store the access token because of `store_in_session` settings then all requests will be allowed as long as the session exists. I'm not sure this is intended.