### PR TITLE
Since we force `opts.prompt = "none"` below the option is retained.

### DIFF
--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -962,6 +962,7 @@ function openidc.authenticate(opts, target_url, unauth_action, session_opts)
         target_url,
         session
     end
+    opts.prompt = nil
     openidc_authorize(opts, session, target_url)
     return nil, nil, target_url, session
   end

--- a/tests/spec/redirect_to_op_spec.lua
+++ b/tests/spec/redirect_to_op_spec.lua
@@ -49,18 +49,6 @@ describe("when accessing the custom protected resource without token", function(
   end)
 end)
 
-describe("when explicitly asking for a prompt parameter", function()
-  test_support.start_server({oidc_opts = {prompt = "none"}})
-  teardown(test_support.stop_server)
-  local _, status, headers = http.request({
-    url = "http://127.0.0.1/default/t",
-    redirect = false
-  })
-  it("then it is included", function()
-    assert.truthy(string.match(headers["location"], ".*prompt=none.*"))
-  end)
-end)
-
 describe("when explicitly asking for a display parameter", function()
   test_support.start_server({oidc_opts = {display = "page"}})
   teardown(test_support.stop_server)


### PR DESCRIPTION
This means if the code is re-called without re-loading `opts` the call
to authenticate will be done with `opts.prompt = "none"` again, where
user interaction would be expected.
This happens if `opts` is declared as a global value in openresty/nginx,
such as by:
`init_by_lua_file "/usr/local/openresty/nginx/conf/conf.d/server.lua";`
in `nginx.conf`, where `server.lua` contains the `opts` structure.
This happens when the server owner needs a global `opts` declaration
reachable by all `server {}` structures in nginx.