### PR TITLE
support OpenID Connect Front Channel Logout

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,9 @@
   endpoint if this has not been done before in order to detect the URI
   of the userinfo endpoint
 
+03/27/2020
+- added a function that implements OpenID Connect Front Channel Logout
+
 02/06/2020
 - ability to disable keepalive from lua-resty-http
   By disabling keepalive we disable the native connection pool,

--- a/README.md
+++ b/README.md
@@ -311,6 +311,43 @@ local res, err, target, session = require("resty.openidc").authenticate(opts)
 session:close()
 ```
 
+## Front-Channel Logout
+
+The `front_channel_logout` function can be used as a content handler
+to implement [OpenID Connect Front-Channel
+Logout](https://openid.net/specs/openid-connect-frontchannel-1_0.html).
+
+```nginx
+  ...
+  location /fc-logout {
+    content_by_lua_block {
+      local opts = {
+        -- session_required = true,
+        -- If this parameter is not set or set to true, requests to
+        -- the front channel logout URI must include the iss and sid
+        -- parameters.
+        -- This also requires id_tokens to be stored inside of the session.
+        -- Default is true
+
+        -- opts.iss = '...',
+        -- if session_required is false the iss parameter can be
+        -- compared to a hard-coded iss value.
+        -- Default is nil
+
+        -- downstream_logout = { 'other-uri', 'yet-another-uri' }
+        -- can contain a table of URIs to be notified via new iframes
+        -- included inside of the response
+        -- Default is no downstream logout URIs at all
+      }
+      require("resty.openidc").front_channel_logout(opts)
+    }
+  }
+```
+
+The `front_channel_logout` accepts as an optional second argument a
+table that is passed to `session.open` in order to read the existing
+session.
+
 ## Sample Configuration for OAuth 2.0 JWT Token Validation
 
 Sample `nginx.conf` configuration for verifying Bearer JWT Access Tokens against a pre-configured secret/key.

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1741,4 +1741,62 @@ function openidc.set_logging(new_log, new_levels)
   WARN = new_levels.WARN and new_levels.WARN or ngx.WARN
 end
 
+function openidc.front_channel_logout(opts, session_opts)
+  local session, is_existing = r_session.open(session_opts)
+  local logout_success = true
+  log(DEBUG, 'Front-Channel Logout invoked')
+  if not is_existing then
+    log(WARN, 'no session present, nothing to do')
+    logout_success = false
+  else
+    if not session.started then
+      session:start()
+    end
+    local args = ngx.req.get_uri_args()
+    if not (args.sid and args.iss) then
+      log(DEBUG, 'Front-Channel Logout invoked without sid or iss')
+      if opts.session_required == nil or opts.session_required then
+        log(ERROR, 'deny logout as the required session information is missing')
+        logout_success = false
+      end
+    else
+      local id_token = session.data.id_token
+      if (opts.session_required == nil or opts.session_required) and not id_token then
+        log(ERROR, 'as id_token is not stored in session and session is required')
+        logout_success = false
+      end
+      if id_token and id_token.sid and id_token.sid ~= args.sid then
+        log(ERROR, 'Front-Channel Logout sid argument is different from sid stored in id_token')
+        logout_success = false
+      end
+      if id_token and id_token.iss and id_token.iss ~= args.iss then
+        log(ERROR, 'Front-Channel Logout iss argument is different from iss stored in id_token')
+        logout_success = false
+      end
+      if not id_token and opts and opts.iss and opts.iss ~= args.iss then
+        log(ERROR, 'Front-Channel Logout iss argument is different from iss stored in opts')
+        logout_success = false
+      end
+    end
+  end
+  ngx.header['Cache-Control'] = 'no-cache, no-store'
+  ngx.header['Pragma'] = 'no-cache'
+  ngx.header.content_type = 'text/html'
+  if logout_success then
+    log(DEBUG, 'Performing Front-Channel Logout')
+    session:destroy()
+  end
+  ngx.print('<html><body>')
+  if logout_success and opts.downstream_logout then
+    local downstream = type(opts.downstream_logout) == 'table' and opts.downstream_logout
+      or { opts.downstream_logout }
+    local _, d
+    for _, d in pairs(downstream) do
+      log(DEBUG, 'also notify ', d)
+      ngx.print('<iframe src="' .. d .. '">')
+    end
+  end
+  ngx.print('</body></html>')
+end
+
 return openidc

--- a/tests/spec/fc_logout_spec.lua
+++ b/tests/spec/fc_logout_spec.lua
@@ -1,0 +1,317 @@
+local http = require("socket.http")
+local test_support = require("test_support")
+local ltn12 = require("ltn12")
+require 'busted.runner'()
+
+describe('when front_channel_logout URI is invoked with session and all parameters', function()
+  test_support.start_server()
+  teardown(test_support.stop_server)
+  local _, _, cookie = test_support.login()
+  local _, status, headers = http.request({
+      url = 'http://127.0.0.1/fc-logout?iss=http%3A%2F%2F127.0.0.1%2F&sid=test_sid',
+      headers = { cookie = cookie },
+      redirect = false
+  })
+  it('the response contains a default HTML-page', function()
+    assert.are.equals(200, status)
+    assert.are.equals('text/html', headers['content-type'])
+  end)
+  it('the response prohibits caching', function()
+    assert.are.equals('no-cache', headers['pragma'])
+    assert.are.equals('no-cache, no-store', headers['cache-control'])
+  end)
+  it('the session cookie has been revoked', function()
+    assert.truthy(string.match(headers['set-cookie'],
+                               'session=; Expires=Thu, 01 Jan 1970 00:00:01 GMT.*'))
+  end)
+end)
+
+describe('when front_channel_logout URI is invoked without session', function()
+  test_support.start_server()
+  teardown(test_support.stop_server)
+  local _, _, cookie = test_support.login()
+  local _, status, headers = http.request({
+      url = 'http://127.0.0.1/fc-logout?iss=http%3A%2F%2F127.0.0.1%2F&sid=test_sid',
+      redirect = false
+  })
+  it('the response contains a default HTML-page', function()
+    assert.are.equals(200, status)
+    assert.are.equals('text/html', headers['content-type'])
+  end)
+  it('the response prohibits caching', function()
+    assert.are.equals('no-cache', headers['pragma'])
+    assert.are.equals('no-cache, no-store', headers['cache-control'])
+  end)
+  it('nothing happens to the session cookie', function()
+    assert.falsy(headers['set-cookie'])
+  end)
+  it('a useful error message is logged', function()
+    assert.error_log_contains('no session present')
+  end)
+end)
+
+describe('when front_channel_logout URI is invoked without id_token in session', function()
+  test_support.start_server({ oidc_opts = { session_contents = { id_token = false } } })
+  teardown(test_support.stop_server)
+  local _, _, cookie = test_support.login()
+  local _, status, headers = http.request({
+      url = 'http://127.0.0.1/fc-logout?iss=http%3A%2F%2F127.0.0.1%2F&sid=test_sid',
+      headers = { cookie = cookie },
+      redirect = false
+  })
+  it('the response contains a default HTML-page', function()
+    assert.are.equals(200, status)
+    assert.are.equals('text/html', headers['content-type'])
+  end)
+  it('the response prohibits caching', function()
+    assert.are.equals('no-cache', headers['pragma'])
+    assert.are.equals('no-cache, no-store', headers['cache-control'])
+  end)
+  it('nothing happens to the session cookie', function()
+    assert.falsy(headers['set-cookie'])
+  end)
+  it('a useful error message is logged', function()
+    assert.error_log_contains('id_token is not stored in session')
+  end)
+end)
+
+describe('when front_channel_logout URI is invoked without iss', function()
+  test_support.start_server()
+  teardown(test_support.stop_server)
+  local _, _, cookie = test_support.login()
+  local _, status, headers = http.request({
+      url = 'http://127.0.0.1/fc-logout?sid=test_sid',
+      headers = { cookie = cookie },
+      redirect = false
+  })
+  it('the response contains a default HTML-page', function()
+    assert.are.equals(200, status)
+    assert.are.equals('text/html', headers['content-type'])
+  end)
+  it('the response prohibits caching', function()
+    assert.are.equals('no-cache', headers['pragma'])
+    assert.are.equals('no-cache, no-store', headers['cache-control'])
+  end)
+  it('nothing happens to the session cookie', function()
+    assert.falsy(headers['set-cookie'])
+  end)
+  it('a useful error message is logged', function()
+    assert.error_log_contains('required session information is missing')
+  end)
+end)
+
+describe('when front_channel_logout URI is invoked with bad iss', function()
+  test_support.start_server()
+  teardown(test_support.stop_server)
+  local _, _, cookie = test_support.login()
+  local _, status, headers = http.request({
+      url = 'http://127.0.0.1/fc-logout?iss=http%3A%2F%2F127.0.0.2%2F&sid=test_sid',
+      headers = { cookie = cookie },
+      redirect = false
+  })
+  it('the response contains a default HTML-page', function()
+    assert.are.equals(200, status)
+    assert.are.equals('text/html', headers['content-type'])
+  end)
+  it('the response prohibits caching', function()
+    assert.are.equals('no-cache', headers['pragma'])
+    assert.are.equals('no-cache, no-store', headers['cache-control'])
+  end)
+  it('nothing happens to the session cookie', function()
+    assert.falsy(headers['set-cookie'])
+  end)
+  it('a useful error message is logged', function()
+    assert.error_log_contains('iss argument is different from iss stored in id_token')
+  end)
+end)
+
+describe('when front_channel_logout URI is invoked without sid', function()
+  test_support.start_server()
+  teardown(test_support.stop_server)
+  local _, _, cookie = test_support.login()
+  local _, status, headers = http.request({
+      url = 'http://127.0.0.1/fc-logout?iss=http%3A%2F%2F127.0.0.1%2F',
+      headers = { cookie = cookie },
+      redirect = false
+  })
+  it('the response contains a default HTML-page', function()
+    assert.are.equals(200, status)
+    assert.are.equals('text/html', headers['content-type'])
+  end)
+  it('the response prohibits caching', function()
+    assert.are.equals('no-cache', headers['pragma'])
+    assert.are.equals('no-cache, no-store', headers['cache-control'])
+  end)
+  it('nothing happens to the session cookie', function()
+    assert.falsy(headers['set-cookie'])
+  end)
+  it('a useful error message is logged', function()
+    assert.error_log_contains('required session information is missing')
+  end)
+end)
+
+describe('when front_channel_logout URI is invoked with bad sid', function()
+  test_support.start_server()
+  teardown(test_support.stop_server)
+  local _, _, cookie = test_support.login()
+  local _, status, headers = http.request({
+      url = 'http://127.0.0.1/fc-logout?iss=http%3A%2F%2F127.0.0.1%2F&sid=test_sid2',
+      headers = { cookie = cookie },
+      redirect = false
+  })
+  it('the response contains a default HTML-page', function()
+    assert.are.equals(200, status)
+    assert.are.equals('text/html', headers['content-type'])
+  end)
+  it('the response prohibits caching', function()
+    assert.are.equals('no-cache', headers['pragma'])
+    assert.are.equals('no-cache, no-store', headers['cache-control'])
+  end)
+  it('nothing happens to the session cookie', function()
+    assert.falsy(headers['set-cookie'])
+  end)
+  it('a useful error message is logged', function()
+    assert.error_log_contains('sid argument is different from sid stored in id_token')
+  end)
+end)
+
+describe('when no session is required', function()
+  describe('and no id_token is present', function()
+    test_support.start_server({
+        oidc_opts = { session_contents = { id_token = false } },
+        fc_logout_opts = { session_required = false }
+    })
+    teardown(test_support.stop_server)
+    local _, _, cookie = test_support.login()
+    local _, status, headers = http.request({
+        url = 'http://127.0.0.1/fc-logout?iss=http%3A%2F%2F127.0.0.1%2F&sid=test_sid',
+        headers = { cookie = cookie },
+        redirect = false
+    })
+    it('the response contains a default HTML-page', function()
+         assert.are.equals(200, status)
+         assert.are.equals('text/html', headers['content-type'])
+    end)
+    it('the response prohibits caching', function()
+         assert.are.equals('no-cache', headers['pragma'])
+         assert.are.equals('no-cache, no-store', headers['cache-control'])
+    end)
+    it('the session cookie has been revoked', function()
+         assert.truthy(string.match(headers['set-cookie'],
+                                    'session=; Expires=Thu, 01 Jan 1970 00:00:01 GMT.*'))
+    end)
+  end)
+  describe('and session parameters are missing', function()
+    test_support.start_server({
+        fc_logout_opts = { session_required = false }
+    })
+    teardown(test_support.stop_server)
+    local _, _, cookie = test_support.login()
+    local _, status, headers = http.request({
+        url = 'http://127.0.0.1/fc-logout',
+        headers = { cookie = cookie },
+        redirect = false
+    })
+    it('the response contains a default HTML-page', function()
+         assert.are.equals(200, status)
+         assert.are.equals('text/html', headers['content-type'])
+    end)
+    it('the response prohibits caching', function()
+         assert.are.equals('no-cache', headers['pragma'])
+         assert.are.equals('no-cache, no-store', headers['cache-control'])
+    end)
+    it('the session cookie has been revoked', function()
+         assert.truthy(string.match(headers['set-cookie'],
+                                    'session=; Expires=Thu, 01 Jan 1970 00:00:01 GMT.*'))
+    end)
+  end)
+  describe('and opts.iss matches iss parameter', function()
+    test_support.start_server({
+        oidc_opts = { session_contents = { id_token = false } },
+        fc_logout_opts = { session_required = false, iss = 'http://127.0.0.1/' }
+    })
+    teardown(test_support.stop_server)
+    local _, _, cookie = test_support.login()
+    local _, status, headers = http.request({
+        url = 'http://127.0.0.1/fc-logout?iss=http%3A%2F%2F127.0.0.1%2F&sid=test_sid',
+        headers = { cookie = cookie },
+        redirect = false
+    })
+    it('the response contains a default HTML-page', function()
+         assert.are.equals(200, status)
+         assert.are.equals('text/html', headers['content-type'])
+    end)
+    it('the response prohibits caching', function()
+         assert.are.equals('no-cache', headers['pragma'])
+         assert.are.equals('no-cache, no-store', headers['cache-control'])
+    end)
+    it('the session cookie has been revoked', function()
+         assert.truthy(string.match(headers['set-cookie'],
+                                    'session=; Expires=Thu, 01 Jan 1970 00:00:01 GMT.*'))
+    end)
+  end)
+  describe('and opts.iss is present but parameter is differemt', function()
+    test_support.start_server({
+        oidc_opts = { session_contents = { id_token = false } },
+        fc_logout_opts = { session_required = false, iss = 'http://127.0.0.1/' }
+    })
+    teardown(test_support.stop_server)
+    local _, _, cookie = test_support.login()
+    local _, status, headers = http.request({
+        url = 'http://127.0.0.1/fc-logout?iss=http%3A%2F%2F127.0.0.2%2F&sid=test_sid',
+        headers = { cookie = cookie },
+        redirect = false
+    })
+    it('the response contains a default HTML-page', function()
+         assert.are.equals(200, status)
+         assert.are.equals('text/html', headers['content-type'])
+    end)
+    it('the response prohibits caching', function()
+         assert.are.equals('no-cache', headers['pragma'])
+         assert.are.equals('no-cache, no-store', headers['cache-control'])
+    end)
+    it('nothing happens to the session cookie', function()
+         assert.falsy(headers['set-cookie'])
+    end)
+    it('a useful error message is logged', function()
+         assert.error_log_contains('iss argument is different from iss stored in opts')
+    end)
+  end)
+end)
+
+describe('when a single downstream logout URI is configured', function()
+  test_support.start_server({
+      fc_logout_opts = { downstream_logout = '/downstream' }
+  })
+  teardown(test_support.stop_server)
+  local _, _, cookie = test_support.login()
+  local content_table = {}
+  local _, status, headers = http.request({
+      url = 'http://127.0.0.1/fc-logout?iss=http%3A%2F%2F127.0.0.1%2F&sid=test_sid',
+      headers = { cookie = cookie },
+      redirect = false,
+      sink = ltn12.sink.table(content_table)
+  })
+  it('the response contains an iframe for downstream', function()
+    assert.truthy(string.match(table.concat(content_table), '<iframe src="/downstream"'))
+  end)
+end)
+
+describe('when a multiple downstream logout URIs are configured', function()
+  test_support.start_server({
+      fc_logout_opts = { downstream_logout = { '/downstream1', '/downstream2' } }
+  })
+  teardown(test_support.stop_server)
+  local _, _, cookie = test_support.login()
+  local content_table = {}
+  local _, status, headers = http.request({
+      url = 'http://127.0.0.1/fc-logout?iss=http%3A%2F%2F127.0.0.1%2F&sid=test_sid',
+      headers = { cookie = cookie },
+      redirect = false,
+      sink = ltn12.sink.table(content_table)
+  })
+  it('the response contains an iframe for downstream', function()
+    assert.truthy(string.match(table.concat(content_table), '<iframe src="/downstream1"'))
+    assert.truthy(string.match(table.concat(content_table), '<iframe src="/downstream2"'))
+  end)
+end)


### PR DESCRIPTION
this adds a function that can be used as lua content handler for a frontchannel logout URI.

see also #308
