### PR TITLE
Make revoke_token() accessible

### DIFF
--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1201,7 +1201,7 @@ local function openidc_authorization_response(opts, session)
 end
 
 -- token revocation (RFC 7009)
-local function openidc.revoke_token(opts, token_type_hint, token)
+function openidc.revoke_token(opts, token_type_hint, token)
   if not opts.discovery.revocation_endpoint then
     log(DEBUG, "no revocation endpoint supplied. unable to revoke " .. token_type_hint .. ".")
     return nil


### PR DESCRIPTION
Enables the usage of revoke_token() for use cases which needs token revocation without logout.