### PR TITLE
Logout with client id parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ h2JHukolz9xf6qN61QMLSd83+kwoBr2drp6xg3eGDLIkQCQLrkY=
              -- Where should the user be redirected after logout from the RP. This option overides any end_session_endpoint that the OP may have provided in the discovery response.
              --redirect_after_logout_with_id_token_hint = true,
              -- Whether the redirection after logout should include the id token as an hint (if available). This option is used only if redirect_after_logout_uri is set.
+             --redirect_after_logout_with_client_id = true,
+             -- Whether the redirection after logout should include the client id (if available).
              --post_logout_redirect_uri = "https://www.zmartzone.eu/logoutSuccessful",
              -- Where does the RP requests that the OP redirects the user after logout. If this option is set to a relative URI, it will be relative to the OP's logout endpoint, not the RP's.
 

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1381,7 +1381,7 @@ local function openidc_logout(opts, session)
     local params = {}
     if (opts.redirect_after_logout_with_id_token_hint or not opts.redirect_after_logout_uri) and session_token then
       params["id_token_hint"] = session_token
-    else
+    elseif opts.redirect_after_logout_with_client_id and opts.client_id then
       params["client_id"] = opts.client_id
     end
     if opts.post_logout_redirect_uri then

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1330,8 +1330,8 @@ local function openidc_logout(opts, session)
     local params = {}
     if (opts.redirect_after_logout_with_id_token_hint or not opts.redirect_after_logout_uri) and session_token then
       params["id_token_hint"] = session_token
-	else
-	  params["client_id"] = opts.client_id
+    else
+      params["client_id"] = opts.client_id
     end
     if opts.post_logout_redirect_uri then
       params["post_logout_redirect_uri"] = opts.post_logout_redirect_uri

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1330,6 +1330,8 @@ local function openidc_logout(opts, session)
     local params = {}
     if (opts.redirect_after_logout_with_id_token_hint or not opts.redirect_after_logout_uri) and session_token then
       params["id_token_hint"] = session_token
+	else
+	  params["client_id"] = opts.client_id
     end
     if opts.post_logout_redirect_uri then
       params["post_logout_redirect_uri"] = opts.post_logout_redirect_uri


### PR DESCRIPTION
Logout with client_id parameter is allowed due to openid specification. When id_token_hint is not specified, client_id can be used instead. This change is a solution for situation when session_token is expired and in the logout operation we get the error message "Missing Parameters: id_token_hint error on Session timeout.".