### PR TITLE
Skip dropping request on code request parameter

### DIFF
--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1530,7 +1530,7 @@ function openidc.authenticate(opts, target_url, unauth_action, session_or_opts)
 
   -- see if this is a request to the redirect_uri i.e. an authorization response
   local path = openidc_get_path(target_url)
-  if path == openidc_get_redirect_uri_path(opts) then
+  if path == openidc_get_redirect_uri_path(opts) and target_url:find("&state=") then
     log(DEBUG, "Redirect URI path (" .. path .. ") is currently navigated -> Processing authorization response coming from OP")
 
     if not session_present then


### PR DESCRIPTION
By default if someone makes a GET request with parameter `&code=...` after authentication against IdP 
classic error `request to the redirect_uri path but there's no session state found` will be raised. 


I believe that it's related to 

```
local function openidc_get_path(uri)
  local without_query = uri:match("(.-)%?") or uri
  return without_query:match(".-//[^/]+(/.*)") or without_query
end
```

Where basically &code matches the regex which triggers authorization response from OP. 

`&code=` alone without extra request parameter  should be treated as authorization response ? 

Eventough I don't believe that this is a viable solution but the issue seems to be present