### PR TITLE
feat: add pushed authorization request support

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+unreleased
+- added support for OAuth 2.0 Pushed Authorization Requests (PAR,
+  RFC 9126) through the opt-in use_par option.
+
 09/13/204
 - cross-tenant requests are fixed with lua-resty session 4.0.x; closes #526
 - release 1.8.0

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
 unreleased
 - added support for OAuth 2.0 Pushed Authorization Requests (PAR,
   RFC 9126) through the opt-in use_par option.
+- propagate errors returned by the `lifecycle.on_created` hook during
+  authorization redirects.
 
 09/13/204
 - cross-tenant requests are fixed with lua-resty session 4.0.x; closes #526

--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ h2JHukolz9xf6qN61QMLSd83+kwoBr2drp6xg3eGDLIkQCQLrkY=
 
              --response_mode=form_post can be used to make lua-resty-openidc use the [OAuth 2.0 Form Post Response Mode](https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html). *Note* for modern browsers you will need to set [`$session_cookie_samesite`](https://github.com/bungle/lua-resty-session#string-sessioncookiesamesite) to `None` with form_post unless your OpenID Connect Provider and Relying Party share the same domain.
              --authorization_params = { hd="zmartzone.eu" },
+             -- When use_par is set to true, lua-resty-openidc will use OAuth 2.0 Pushed Authorization Requests (PAR, RFC 9126).
+             -- The authorization request parameters are posted to the pushed_authorization_request_endpoint from discovery,
+             -- and the browser is redirected to the authorization endpoint with the returned request_uri.
+             --use_par = false,
+             -- Override the PAR endpoint from discovery when needed.
+             --pushed_authorization_request_endpoint = "https://MY_OP/pushed_authorization_request",
+             -- Override the client authentication method for the PAR endpoint. Defaults to token_endpoint_auth_method.
+             --pushed_authorization_request_endpoint_auth_method = "client_secret_basic",
              --scope = "openid email profile",
              -- Refresh the users id_token after 900 seconds without requiring re-authentication
              --refresh_session_interval = 900,

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -77,6 +77,11 @@ local supported_token_auth_methods = {
   client_secret_jwt = token_auth_method_precondition('client_secret_jwt', 'client_secret')
 }
 
+local function can_use_token_auth_method(method, opts)
+  local supported = supported_token_auth_methods[method]
+  return supported and (type(supported) ~= 'function' or supported(opts))
+end
+
 local openidc = {
   _VERSION = "1.8.0"
 }
@@ -339,16 +344,18 @@ local function openidc_pushed_authorization_request(opts, params)
   end
 
   local auth = opts.pushed_authorization_request_endpoint_auth_method
-      or opts.token_endpoint_auth_method
-  local supported_auth = supported_token_auth_methods[auth]
-  if auth and (not supported_auth
-      or (type(supported_auth) == 'function' and not supported_auth(opts))) then
-    return nil, "configured value for pushed_authorization_request_endpoint_auth_method ("
+  local auth_option = "pushed_authorization_request_endpoint_auth_method"
+  if not auth then
+    auth = opts.token_endpoint_auth_method
+    auth_option = "token_endpoint_auth_method"
+  end
+  if auth and not can_use_token_auth_method(auth, opts) then
+    return nil, "configured value for " .. auth_option .. " ("
         .. auth .. ") is not supported"
   end
 
   local json, err = openidc.call_token_endpoint(opts, endpoint, params, auth,
-      "pushed authorization request", false, 201)
+      "pushed authorization request", false, { 200, 201 })
   if err then
     return nil, err
   end
@@ -712,11 +719,6 @@ function openidc.call_userinfo_endpoint(opts, access_token)
 
   -- parse the response from the user info endpoint
   return openidc_parse_json_response(res)
-end
-
-local function can_use_token_auth_method(method, opts)
-  local supported = supported_token_auth_methods[method]
-  return supported and (type(supported) ~= 'function' or supported(opts))
 end
 
 -- get the token endpoint authentication method

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -310,12 +310,54 @@ local function decorate_request(http_request_decorator, req)
   return http_request_decorator and http_request_decorator(req) or req
 end
 
+local function openidc_is_expected_response_status(response_status, expected_status)
+  if type(expected_status) == "table" then
+    for _, status in ipairs(expected_status) do
+      if response_status == status then
+        return true
+      end
+    end
+    return false
+  end
+
+  return response_status == expected_status
+end
+
 local sha256 = (require 'resty.sha256'):new()
 local function openidc_s256(verifier)
   sha256:update(verifier)
   local s256 = b64url(sha256:final())
   sha256:reset()
   return s256
+end
+
+local function openidc_pushed_authorization_request(opts, params)
+  local endpoint = opts.pushed_authorization_request_endpoint
+      or opts.discovery.pushed_authorization_request_endpoint
+  if not endpoint then
+    return nil, "no pushed authorization request endpoint URI"
+  end
+
+  local auth = opts.pushed_authorization_request_endpoint_auth_method
+      or opts.token_endpoint_auth_method
+  local supported_auth = supported_token_auth_methods[auth]
+  if auth and (not supported_auth
+      or (type(supported_auth) == 'function' and not supported_auth(opts))) then
+    return nil, "configured value for pushed_authorization_request_endpoint_auth_method ("
+        .. auth .. ") is not supported"
+  end
+
+  local json, err = openidc.call_token_endpoint(opts, endpoint, params, auth,
+      "pushed authorization request", false, 201)
+  if err then
+    return nil, err
+  end
+
+  if not json.request_uri then
+    return nil, "pushed authorization request response did not contain a request_uri"
+  end
+
+  return json
 end
 
 -- send the browser of to the OP's authorization endpoint
@@ -386,20 +428,35 @@ local function openidc_authorize(opts, session, target_url, prompt)
     log(WARN, "unable to save session: " .. err)
   end
 
+  if opts.use_par then
+    local par_response
+    par_response, err = openidc_pushed_authorization_request(opts, params)
+    if err then
+      log(ERROR, "pushed authorization request failed: " .. err)
+      return err
+    end
+
+    params = {
+      client_id = opts.client_id,
+      request_uri = par_response.request_uri
+    }
+  end
+
   -- redirect to the /authorization endpoint
   ngx.header["Cache-Control"] = "no-cache, no-store, max-age=0"
   return ngx.redirect(openidc_combine_uri(opts.discovery.authorization_endpoint, params))
 end
 
 -- parse the JSON result from a call to the OP
-local function openidc_parse_json_response(response, ignore_body_on_success)
+local function openidc_parse_json_response(response, ignore_body_on_success, expected_status)
   local ignore_body_on_success = ignore_body_on_success or false
+  local expected_status = expected_status or 200
 
   local err
   local res
 
   -- check the response from the OP
-  if response.status ~= 200 then
+  if not openidc_is_expected_response_status(response.status, expected_status) then
     err = "response indicates failure, status=" .. response.status .. ", body=" .. response.body
   else
     if ignore_body_on_success then
@@ -438,7 +495,7 @@ local function openidc_configure_proxy(httpc, proxy_opts)
 end
 
 -- make a call to the token endpoint
-function openidc.call_token_endpoint(opts, endpoint, body, auth, endpoint_name, ignore_body_on_success)
+function openidc.call_token_endpoint(opts, endpoint, body, auth, endpoint_name, ignore_body_on_success, expected_status)
   local ignore_body_on_success = ignore_body_on_success or false
 
   local ep_name = endpoint_name or 'token'
@@ -534,7 +591,7 @@ function openidc.call_token_endpoint(opts, endpoint, body, auth, endpoint_name, 
 
   log(DEBUG, ep_name .. " endpoint response: ", res.body)
 
-  return openidc_parse_json_response(res, ignore_body_on_success)
+  return openidc_parse_json_response(res, ignore_body_on_success, expected_status)
 end
 
 -- computes access_token expires_in value (in seconds)
@@ -1614,7 +1671,10 @@ function openidc.authenticate(opts, target_url, unauth_action, session_or_opts)
     end
 
     log(DEBUG, "Authentication is required - Redirecting to OP Authorization endpoint")
-    openidc_authorize(opts, session, target_url, opts.prompt)
+    err = openidc_authorize(opts, session, target_url, opts.prompt)
+    if err then
+      return nil, err, session:get("original_url"), session
+    end
     return nil, nil, target_url, session
   end
 
@@ -1628,7 +1688,10 @@ function openidc.authenticate(opts, target_url, unauth_action, session_or_opts)
       end
 
       log(DEBUG, "Silent authentication is required - Redirecting to OP Authorization endpoint")
-      openidc_authorize(opts, session, target_url, "none")
+      err = openidc_authorize(opts, session, target_url, "none")
+      if err then
+        return nil, err, session:get("original_url"), session
+      end
       return nil, nil, target_url, session
     end
   end

--- a/tests/spec/par_spec.lua
+++ b/tests/spec/par_spec.lua
@@ -101,6 +101,34 @@ describe("when PAR is enabled using client_secret_basic", function()
   end)
 end)
 
+describe("when the PAR endpoint returns HTTP 200", function()
+  local status, headers
+
+  setup(function()
+    test_support.start_server({
+      oidc_opts = par_opts({
+        discovery = {
+          pushed_authorization_request_endpoint = "http://127.0.0.1/par-200",
+        }
+      })
+    })
+
+    local _
+    _, status, headers = http.request({
+      url = "http://127.0.0.1/default/t",
+      redirect = false
+    })
+  end)
+
+  teardown(test_support.stop_server)
+
+  it("accepts the response for interoperability", function()
+    assert.are.equals(302, status)
+    assert.truthy(string.find(headers["location"], "request_uri=", 1, true))
+    assert.truthy(string.find(headers["location"], "test-200", 1, true))
+  end)
+end)
+
 describe("when PAR is enabled using private_key_jwt", function()
   setup(function()
     test_support.start_server({

--- a/tests/spec/par_spec.lua
+++ b/tests/spec/par_spec.lua
@@ -1,0 +1,237 @@
+local test_support = require("test_support")
+require 'busted.runner'()
+
+local function par_opts(extra)
+  local opts = {
+    use_par = true,
+    discovery = {
+      pushed_authorization_request_endpoint = "http://127.0.0.1/par",
+    }
+  }
+  if extra then
+    for k, v in pairs(extra) do
+      opts[k] = v
+    end
+  end
+  return opts
+end
+
+local function assert_par_endpoint_call_contains(s, case_insensitive)
+  assert.error_log_contains("request body for pushed authorization request endpoint call: .*"
+      .. s .. ".*", case_insensitive)
+end
+
+describe("when PAR is enabled", function()
+  test_support.start_server({
+    oidc_opts = par_opts()
+  })
+  teardown(test_support.stop_server)
+
+  local _, status, headers = http.request({
+    url = "http://127.0.0.1/default/t",
+    redirect = false
+  })
+
+  it("posts the authorization request parameters to the PAR endpoint", function()
+    assert_par_endpoint_call_contains("response_type=code")
+    assert_par_endpoint_call_contains("client_id=client_id")
+    assert_par_endpoint_call_contains("scope=" .. test_support.urlescape_for_regex("openid email profile"))
+    assert_par_endpoint_call_contains("redirect_uri="
+        .. test_support.urlescape_for_regex("http://localhost/default/redirect_uri"), true)
+    assert_par_endpoint_call_contains("state=")
+    assert_par_endpoint_call_contains("nonce=")
+  end)
+
+  it("uses the configured client authentication for the PAR endpoint", function()
+    assert_par_endpoint_call_contains("client_secret=client_secret")
+  end)
+
+  it("redirects to the authorization endpoint with the request_uri", function()
+    assert.are.equals(302, status)
+    assert.truthy(string.match(headers["location"], "http://127.0.0.1/authorize%?.*client_id=client_id.*"))
+    assert.truthy(string.match(string.lower(headers["location"]), ".*request_uri="
+        .. string.lower(test_support.urlescape_for_regex("urn:ietf:params:oauth:request_uri:test")) .. ".*"))
+  end)
+
+  it("does not expose full authorization parameters in the browser redirect", function()
+    assert.falsy(string.match(headers["location"], ".*scope=.*"))
+    assert.falsy(string.match(headers["location"], ".*nonce=.*"))
+    assert.falsy(string.match(headers["location"], ".*redirect_uri=.*"))
+    assert.falsy(string.match(headers["location"], ".*state=.*"))
+  end)
+
+  it("disables HTTP caching on the redirect response", function()
+    assert.are.equals("no-cache, no-store, max-age=0", headers["cache-control"])
+  end)
+end)
+
+describe("when PAR is enabled using client_secret_basic", function()
+  test_support.start_server({
+    oidc_opts = par_opts({
+      discovery = {
+        pushed_authorization_request_endpoint = "http://127.0.0.1/par",
+        token_endpoint_auth_methods_supported = { "client_secret_basic" },
+      }
+    })
+  })
+  teardown(test_support.stop_server)
+
+  http.request({
+    url = "http://127.0.0.1/default/t",
+    redirect = false
+  })
+
+  it("uses a basic auth header for the PAR endpoint", function()
+    assert.error_log_contains("par authorization header: Basic")
+  end)
+
+  it("does not send the client_secret in the PAR request body", function()
+    assert.is_not.error_log_contains(
+        "request body for pushed authorization request endpoint call: .*client_secret=client_secret.*")
+  end)
+end)
+
+describe("when PAR is enabled using private_key_jwt", function()
+  test_support.start_server({
+    oidc_opts = par_opts({
+      discovery = {
+        pushed_authorization_request_endpoint = "http://127.0.0.1/par",
+        token_endpoint_auth_methods_supported = { "private_key_jwt" },
+      },
+      token_endpoint_auth_method = "private_key_jwt",
+      client_rsa_private_key = test_support.load("/spec/private_rsa_key.pem"),
+    })
+  })
+  teardown(test_support.stop_server)
+
+  http.request({
+    url = "http://127.0.0.1/default/t",
+    redirect = false
+  })
+
+  it("sends a private_key_jwt client assertion to the PAR endpoint", function()
+    assert_par_endpoint_call_contains("client_assertion=ey")
+    assert_par_endpoint_call_contains(
+        "client_assertion_type=urn%%3Aietf%%3Aparams%%3Aoauth%%3Aclient%-assertion%-type%%3Ajwt%-bearer")
+  end)
+end)
+
+describe("when PAR is enabled with an unsupported client authentication method", function()
+  test_support.start_server({
+    oidc_opts = par_opts({
+      pushed_authorization_request_endpoint_auth_method = "unsupported_auth",
+    })
+  })
+  teardown(test_support.stop_server)
+
+  local _, status = http.request({
+    url = "http://127.0.0.1/default/t",
+    redirect = false
+  })
+
+  it("fails authentication", function()
+    assert.are.equals(401, status)
+  end)
+
+  it("logs the unsupported PAR authentication method", function()
+    assert.error_log_contains(
+        "authenticate failed: configured value for pushed_authorization_request_endpoint_auth_method %(unsupported_auth%) is not supported")
+  end)
+end)
+
+describe("when PAR is enabled but no endpoint is configured", function()
+  test_support.start_server({
+    oidc_opts = {
+      use_par = true,
+    }
+  })
+  teardown(test_support.stop_server)
+
+  local _, status = http.request({
+    url = "http://127.0.0.1/default/t",
+    redirect = false
+  })
+
+  it("fails authentication", function()
+    assert.are.equals(401, status)
+  end)
+
+  it("logs a clear error", function()
+    assert.error_log_contains(
+        "authenticate failed: no pushed authorization request endpoint URI")
+  end)
+end)
+
+describe("when the PAR endpoint sends a 4xx status", function()
+  test_support.start_server({
+    oidc_opts = par_opts({
+      discovery = {
+        pushed_authorization_request_endpoint = "http://127.0.0.1/not-there",
+      }
+    })
+  })
+  teardown(test_support.stop_server)
+
+  local _, status = http.request({
+    url = "http://127.0.0.1/default/t",
+    redirect = false
+  })
+
+  it("fails authentication", function()
+    assert.are.equals(401, status)
+  end)
+
+  it("logs the PAR response failure", function()
+    assert.error_log_contains(
+        "authenticate failed: response indicates failure, status=404,")
+  end)
+end)
+
+describe("when the PAR endpoint does not return JSON", function()
+  test_support.start_server({
+    oidc_opts = par_opts({
+      discovery = {
+        pushed_authorization_request_endpoint = "http://127.0.0.1/par-invalid-json",
+      }
+    })
+  })
+  teardown(test_support.stop_server)
+
+  local _, status = http.request({
+    url = "http://127.0.0.1/default/t",
+    redirect = false
+  })
+
+  it("fails authentication", function()
+    assert.are.equals(401, status)
+  end)
+
+  it("logs the JSON decoding failure", function()
+    assert.error_log_contains("authenticate failed: JSON decoding failed")
+  end)
+end)
+
+describe("when the PAR endpoint response omits request_uri", function()
+  test_support.start_server({
+    oidc_opts = par_opts({
+      discovery = {
+        pushed_authorization_request_endpoint = "http://127.0.0.1/par-no-request-uri",
+      }
+    })
+  })
+  teardown(test_support.stop_server)
+
+  local _, status = http.request({
+    url = "http://127.0.0.1/default/t",
+    redirect = false
+  })
+
+  it("fails authentication", function()
+    assert.are.equals(401, status)
+  end)
+
+  it("logs the missing request_uri", function()
+    assert.error_log_contains(
+        "authenticate failed: pushed authorization request response did not contain a request_uri")
+  end)
+end)

--- a/tests/spec/par_spec.lua
+++ b/tests/spec/par_spec.lua
@@ -1,4 +1,5 @@
 local test_support = require("test_support")
+local http = require("socket.http")
 require 'busted.runner'()
 
 local function par_opts(extra)
@@ -22,15 +23,21 @@ local function assert_par_endpoint_call_contains(s, case_insensitive)
 end
 
 describe("when PAR is enabled", function()
-  test_support.start_server({
-    oidc_opts = par_opts()
-  })
-  teardown(test_support.stop_server)
+  local status, headers
 
-  local _, status, headers = http.request({
-    url = "http://127.0.0.1/default/t",
-    redirect = false
-  })
+  setup(function()
+    test_support.start_server({
+      oidc_opts = par_opts()
+    })
+
+    local _
+    _, status, headers = http.request({
+      url = "http://127.0.0.1/default/t",
+      redirect = false
+    })
+  end)
+
+  teardown(test_support.stop_server)
 
   it("posts the authorization request parameters to the PAR endpoint", function()
     assert_par_endpoint_call_contains("response_type=code")
@@ -66,20 +73,23 @@ describe("when PAR is enabled", function()
 end)
 
 describe("when PAR is enabled using client_secret_basic", function()
-  test_support.start_server({
-    oidc_opts = par_opts({
-      discovery = {
-        pushed_authorization_request_endpoint = "http://127.0.0.1/par",
-        token_endpoint_auth_methods_supported = { "client_secret_basic" },
-      }
+  setup(function()
+    test_support.start_server({
+      oidc_opts = par_opts({
+        discovery = {
+          pushed_authorization_request_endpoint = "http://127.0.0.1/par",
+          token_endpoint_auth_methods_supported = { "client_secret_basic" },
+        }
+      })
     })
-  })
-  teardown(test_support.stop_server)
 
-  http.request({
-    url = "http://127.0.0.1/default/t",
-    redirect = false
-  })
+    http.request({
+      url = "http://127.0.0.1/default/t",
+      redirect = false
+    })
+  end)
+
+  teardown(test_support.stop_server)
 
   it("uses a basic auth header for the PAR endpoint", function()
     assert.error_log_contains("par authorization header: Basic")
@@ -92,22 +102,25 @@ describe("when PAR is enabled using client_secret_basic", function()
 end)
 
 describe("when PAR is enabled using private_key_jwt", function()
-  test_support.start_server({
-    oidc_opts = par_opts({
-      discovery = {
-        pushed_authorization_request_endpoint = "http://127.0.0.1/par",
-        token_endpoint_auth_methods_supported = { "private_key_jwt" },
-      },
-      token_endpoint_auth_method = "private_key_jwt",
-      client_rsa_private_key = test_support.load("/spec/private_rsa_key.pem"),
+  setup(function()
+    test_support.start_server({
+      oidc_opts = par_opts({
+        discovery = {
+          pushed_authorization_request_endpoint = "http://127.0.0.1/par",
+          token_endpoint_auth_methods_supported = { "private_key_jwt" },
+        },
+        token_endpoint_auth_method = "private_key_jwt",
+        client_rsa_private_key = test_support.load("/spec/private_rsa_key.pem"),
+      })
     })
-  })
-  teardown(test_support.stop_server)
 
-  http.request({
-    url = "http://127.0.0.1/default/t",
-    redirect = false
-  })
+    http.request({
+      url = "http://127.0.0.1/default/t",
+      redirect = false
+    })
+  end)
+
+  teardown(test_support.stop_server)
 
   it("sends a private_key_jwt client assertion to the PAR endpoint", function()
     assert_par_endpoint_call_contains("client_assertion=ey")
@@ -117,17 +130,23 @@ describe("when PAR is enabled using private_key_jwt", function()
 end)
 
 describe("when PAR is enabled with an unsupported client authentication method", function()
-  test_support.start_server({
-    oidc_opts = par_opts({
-      pushed_authorization_request_endpoint_auth_method = "unsupported_auth",
-    })
-  })
-  teardown(test_support.stop_server)
+  local status
 
-  local _, status = http.request({
-    url = "http://127.0.0.1/default/t",
-    redirect = false
-  })
+  setup(function()
+    test_support.start_server({
+      oidc_opts = par_opts({
+        pushed_authorization_request_endpoint_auth_method = "unsupported_auth",
+      })
+    })
+
+    local _
+    _, status = http.request({
+      url = "http://127.0.0.1/default/t",
+      redirect = false
+    })
+  end)
+
+  teardown(test_support.stop_server)
 
   it("fails authentication", function()
     assert.are.equals(401, status)
@@ -140,17 +159,23 @@ describe("when PAR is enabled with an unsupported client authentication method",
 end)
 
 describe("when PAR is enabled but no endpoint is configured", function()
-  test_support.start_server({
-    oidc_opts = {
-      use_par = true,
-    }
-  })
-  teardown(test_support.stop_server)
+  local status
 
-  local _, status = http.request({
-    url = "http://127.0.0.1/default/t",
-    redirect = false
-  })
+  setup(function()
+    test_support.start_server({
+      oidc_opts = {
+        use_par = true,
+      }
+    })
+
+    local _
+    _, status = http.request({
+      url = "http://127.0.0.1/default/t",
+      redirect = false
+    })
+  end)
+
+  teardown(test_support.stop_server)
 
   it("fails authentication", function()
     assert.are.equals(401, status)
@@ -163,19 +188,25 @@ describe("when PAR is enabled but no endpoint is configured", function()
 end)
 
 describe("when the PAR endpoint sends a 4xx status", function()
-  test_support.start_server({
-    oidc_opts = par_opts({
-      discovery = {
-        pushed_authorization_request_endpoint = "http://127.0.0.1/not-there",
-      }
-    })
-  })
-  teardown(test_support.stop_server)
+  local status
 
-  local _, status = http.request({
-    url = "http://127.0.0.1/default/t",
-    redirect = false
-  })
+  setup(function()
+    test_support.start_server({
+      oidc_opts = par_opts({
+        discovery = {
+          pushed_authorization_request_endpoint = "http://127.0.0.1/not-there",
+        }
+      })
+    })
+
+    local _
+    _, status = http.request({
+      url = "http://127.0.0.1/default/t",
+      redirect = false
+    })
+  end)
+
+  teardown(test_support.stop_server)
 
   it("fails authentication", function()
     assert.are.equals(401, status)
@@ -188,19 +219,25 @@ describe("when the PAR endpoint sends a 4xx status", function()
 end)
 
 describe("when the PAR endpoint does not return JSON", function()
-  test_support.start_server({
-    oidc_opts = par_opts({
-      discovery = {
-        pushed_authorization_request_endpoint = "http://127.0.0.1/par-invalid-json",
-      }
-    })
-  })
-  teardown(test_support.stop_server)
+  local status
 
-  local _, status = http.request({
-    url = "http://127.0.0.1/default/t",
-    redirect = false
-  })
+  setup(function()
+    test_support.start_server({
+      oidc_opts = par_opts({
+        discovery = {
+          pushed_authorization_request_endpoint = "http://127.0.0.1/par-invalid-json",
+        }
+      })
+    })
+
+    local _
+    _, status = http.request({
+      url = "http://127.0.0.1/default/t",
+      redirect = false
+    })
+  end)
+
+  teardown(test_support.stop_server)
 
   it("fails authentication", function()
     assert.are.equals(401, status)
@@ -212,19 +249,25 @@ describe("when the PAR endpoint does not return JSON", function()
 end)
 
 describe("when the PAR endpoint response omits request_uri", function()
-  test_support.start_server({
-    oidc_opts = par_opts({
-      discovery = {
-        pushed_authorization_request_endpoint = "http://127.0.0.1/par-no-request-uri",
-      }
-    })
-  })
-  teardown(test_support.stop_server)
+  local status
 
-  local _, status = http.request({
-    url = "http://127.0.0.1/default/t",
-    redirect = false
-  })
+  setup(function()
+    test_support.start_server({
+      oidc_opts = par_opts({
+        discovery = {
+          pushed_authorization_request_endpoint = "http://127.0.0.1/par-no-request-uri",
+        }
+      })
+    })
+
+    local _
+    _, status = http.request({
+      url = "http://127.0.0.1/default/t",
+      redirect = false
+    })
+  end)
+
+  teardown(test_support.stop_server)
 
   it("fails authentication", function()
     assert.are.equals(401, status)

--- a/tests/spec/test_support.lua
+++ b/tests/spec/test_support.lua
@@ -299,6 +299,19 @@ http {
             }
         }
 
+        location /par-200 {
+            content_by_lua_block {
+                ngx.req.read_body()
+                ngx.log(ngx.ERR, "Received par request: " .. ngx.req.get_body_data())
+                ngx.header.content_type = 'application/json;charset=UTF-8'
+                ngx.status = 200
+                ngx.say(test_globals.cjson.encode({
+                  request_uri = "urn:ietf:params:oauth:request_uri:test-200",
+                  expires_in = 90,
+                }))
+            }
+        }
+
         location /par-no-request-uri {
             content_by_lua_block {
                 ngx.header.content_type = 'application/json;charset=UTF-8'

--- a/tests/spec/test_support.lua
+++ b/tests/spec/test_support.lua
@@ -284,6 +284,39 @@ http {
             }
         }
 
+        location /par {
+            content_by_lua_block {
+                ngx.req.read_body()
+                ngx.log(ngx.ERR, "Received par request: " .. ngx.req.get_body_data())
+                local auth = ngx.req.get_headers()["Authorization"]
+                ngx.log(ngx.ERR, "par authorization header: " .. (auth and auth or ""))
+                ngx.header.content_type = 'application/json;charset=UTF-8'
+                ngx.status = 201
+                ngx.say(test_globals.cjson.encode({
+                  request_uri = "urn:ietf:params:oauth:request_uri:test",
+                  expires_in = 90,
+                }))
+            }
+        }
+
+        location /par-no-request-uri {
+            content_by_lua_block {
+                ngx.header.content_type = 'application/json;charset=UTF-8'
+                ngx.status = 201
+                ngx.say(test_globals.cjson.encode({
+                  expires_in = 90,
+                }))
+            }
+        }
+
+        location /par-invalid-json {
+            content_by_lua_block {
+                ngx.header.content_type = 'application/json;charset=UTF-8'
+                ngx.status = 201
+                ngx.say('INVALID JSON.')
+            }
+        }
+
         location /verify_bearer_token {
             content_by_lua_block {
                 local opts = VERIFY_OPTS


### PR DESCRIPTION
## Summary

This adds opt-in client support for OAuth 2.0 Pushed Authorization Requests (PAR, RFC 9126) in the authorization code flow.

When `use_par` is enabled, lua-resty-openidc posts the authorization request parameters to the configured or discovered PAR endpoint, then redirects the browser to the authorization endpoint with the returned `request_uri`.

Closes #557

## Changes

- Add `use_par` option for opt-in PAR support.
- Add optional `pushed_authorization_request_endpoint` override.
- Add optional `pushed_authorization_request_endpoint_auth_method`, defaulting to `token_endpoint_auth_method`.
- Reuse existing client authentication handling for the PAR request.
- Accept PAR `200 OK` and `201 Created` response statuses for interoperability without changing the existing default `200 OK` behavior for token/introspection/userinfo calls.
- Share token client authentication method validation with the existing token endpoint selection logic.
- Propagate errors returned by the `lifecycle.on_created` hook during authorization redirects.
- Add tests for successful PAR, client auth reuse, HTTP 200/201 PAR responses, missing endpoint, 4xx responses, invalid JSON, and missing `request_uri`.
- Document the new options in README and ChangeLog.

## Testing

```text
522 successes / 0 failures / 0 errors / 1 pending
```

The one pending test is an existing upstream pending test in `id_token_validation_spec.lua`, unrelated to PAR.