### PR TITLE
Harden test Docker image

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
 unreleased
+- hardened the test Docker image by minimizing apt-installed packages
+  and running the test suite as a non-root user.
 - added support for OAuth 2.0 Pushed Authorization Requests (PAR,
   RFC 9126) through the opt-in use_par option.
 - propagate errors returned by the `lifecycle.on_created` hook during

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -6,8 +6,9 @@ RUN ["luarocks", "install", "lua-resty-http"]
 RUN ["luarocks", "install", "lua-resty-jwt"]
 
 # install test dependencies
-RUN ["apt-get", "update"]
-RUN ["apt-get", "install", "-y", "git"]
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
 RUN ["luarocks", "install", "busted"]
 RUN ["luarocks", "install", "LuaSocket"]
 RUN ["luarocks", "install", "serpent"]
@@ -18,7 +19,9 @@ ADD lib/resty/openidc.lua /usr/local/openresty/lualib/resty/openidc.lua
 
 # mount tests
 ADD tests/spec /spec
+RUN mkdir -p /usr/local/openresty/nginx/client_body_temp \
+    && chown -R nobody:nogroup /spec /usr/local/openresty/nginx
 
-CMD busted -C spec -o plainTerminal . && (test -z "$coverage" || (\
-    luacov -c /spec/luacov/settings.luacov && \
-    cat /spec/luacov/luacov.report.out ) )
+USER nobody
+
+CMD ["sh", "-c", "busted -C spec -o plainTerminal . && (test -z \"$coverage\" || (luacov -c /spec/luacov/settings.luacov && cat /spec/luacov/luacov.report.out))"]


### PR DESCRIPTION
## Summary

Harden the test Docker image so it clears the Dockerfile HIGH findings reported by Trivy.

## Changes

- Combine apt-get update and apt-get install into one layer.
- Install git with --no-install-recommends and clean apt lists.
- Run the test suite as the non-root nobody user after granting the required test/OpenResty runtime directories.
- Convert the test image CMD to JSON exec form.
- Add a ChangeLog entry for the test image hardening.

## Validation

- docker build -f tests/Dockerfile . -t lua-resty-openidc/test
- docker run -t --rm lua-resty-openidc/test:latest
  - 522 successes / 0 failures / 0 errors / 1 pending
- trivy fs --scanners vuln,misconfig,secret --severity HIGH,CRITICAL .
  - tests/Dockerfile: 0 misconfigurations
- trivy image --severity HIGH,CRITICAL lua-resty-openidc/test:latest
  - Ubuntu packages: 0 vulnerabilities
  - Node package: 0 vulnerabilities
  - Remaining HIGH secret findings are the existing test fixture private keys under /spec/*.pem.