### PR TITLE
[codex] Address logout client_id follow-up feedback

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,8 @@ unreleased
   RFC 9126) through the opt-in use_par option.
 - propagate errors returned by the `lifecycle.on_created` hook during
   authorization redirects.
+- add redirect_after_logout_with_client_id option to send client_id on
+  logout when id_token_hint is not available; see #518
 
 09/13/204
 - cross-tenant requests are fixed with lua-resty session 4.0.x; closes #526

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ h2JHukolz9xf6qN61QMLSd83+kwoBr2drp6xg3eGDLIkQCQLrkY=
              --redirect_after_logout_with_id_token_hint = true,
              -- Whether the redirection after logout should include the id token as an hint (if available). This option is used only if redirect_after_logout_uri is set.
              --redirect_after_logout_with_client_id = true,
-             -- Whether the redirection after logout should include the client id (if available).
+             -- Whether the redirection after logout should include the client id when no id_token_hint is sent (if available).
              --post_logout_redirect_uri = "https://www.zmartzone.eu/logoutSuccessful",
              -- Where does the RP requests that the OP redirects the user after logout. If this option is set to a relative URI, it will be relative to the OP's logout endpoint, not the RP's.
 

--- a/tests/spec/logout_spec.lua
+++ b/tests/spec/logout_spec.lua
@@ -590,7 +590,7 @@ describe("when the configured logout uri is invoked with no active session", fun
   end)
 end)
 
-describe("when logout is invoked and a callback with client id has been configured", function()
+describe("when logout is invoked and a callback with client id has been configured but id_token hasn't been cached", function()
   test_support.start_server({
       oidc_opts = {
         discovery = {
@@ -598,9 +598,12 @@ describe("when logout is invoked and a callback with client id has been configur
           ping_end_session_endpoint = "http://127.0.0.1/ping-end-session",
         },
         redirect_after_logout_uri = "http://127.0.0.1/after-logout",
-        redirect_after_logout_with_id_token_hint = false,
+        redirect_after_logout_with_id_token_hint = true,
         redirect_after_logout_with_client_id = true,
         client_id = "client_id",
+        session_contents = {
+          access_token = true
+        }
       }
   })
   teardown(test_support.stop_server)
@@ -616,6 +619,9 @@ describe("when logout is invoked and a callback with client id has been configur
   end)
   it("the redirect contains the client_id", function()
     assert.truthy(string.match(headers["location"], ".*%?client_id=.*"))
+  end)
+  it("the redirect doesn't contain the id_token_hint", function()
+    assert.falsy(string.match(headers["location"], ".*id_token_hint=.*"))
   end)
   it("the session cookie has been revoked", function()
     assert.truthy(string.match(headers["set-cookie"],


### PR DESCRIPTION
## Summary

Follow-up to #518 after it landed on master.

This PR:
- adds the missing ChangeLog entry for redirect_after_logout_with_client_id
- clarifies that client_id is sent only when no id_token_hint is sent
- updates the logout regression test to cover the intended fallback case where the encrypted id token is not cached but client_id fallback is enabled

## Validation

- docker build -f tests/Dockerfile . -t lua-resty-openidc/test
- docker run -t --rm lua-resty-openidc/test:latest (507 successes / 0 failures / 0 errors / 1 pending)
- git diff --check upstream/master...HEAD