### PR TITLE
[codex] Add security policy

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 unreleased
+- added a security policy for privately reporting vulnerabilities.
 - added maintenance automation for dependency updates and pull request
   contribution checks.
 - hardened the test Docker image by minimizing apt-installed packages

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided for the latest released version of
+lua-resty-openidc.
+
+Older versions may receive security fixes at the maintainers' discretion.
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues.
+
+If you believe you have found a security vulnerability, please report it
+privately using GitHub's private vulnerability reporting, if available, or
+contact the maintainers directly.
+
+When reporting a vulnerability, please include:
+
+- A description of the issue
+- Steps to reproduce the behavior
+- Affected lua-resty-openidc versions
+- Relevant OpenResty, NGINX, and dependency versions
+- Any known mitigations or workarounds
+
+The maintainers will review the report and coordinate disclosure once the issue
+has been assessed and, where appropriate, a fix is available.
+
+## Scope
+
+Security vulnerabilities may include issues affecting authentication,
+authorization, token validation, session handling, redirect handling,
+cryptographic validation, or disclosure of sensitive information.
+
+General bugs, configuration questions, and feature requests should be reported
+through regular GitHub issues.


### PR DESCRIPTION
## Summary

Adds a `SECURITY.md` policy that explains how security vulnerabilities should be reported privately and clarifies the general scope for security issues in lua-resty-openidc.

The policy intentionally avoids strict response-time or long-term support commitments while giving reporters useful information to include, such as affected versions and relevant OpenResty, NGINX, and dependency versions.

## Validation

- Verified the branch is based on the latest `upstream/master`.
- Verified the PR diff only includes `SECURITY.md` and the `ChangeLog` entry.
- Did not run the Docker test suite because this is a documentation-only change.