### PR TITLE
Scope DPoP nonces per request instead of mutating shared opts

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
 unreleased
+- scope DPoP nonces to the current request (via ngx.ctx) instead of
+  mutating the shared opts table, preventing one session's DPoP nonce
+  from leaking into another request; the per-user token nonce continues
+  to be persisted in the session.
 - added a security policy for privately reporting vulnerabilities.
 - added maintenance automation for dependency updates and pull request
   contribution checks.

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -715,6 +715,27 @@ local function openidc_dpop_nonce_from_response(res, accepted_statuses)
   return nil
 end
 
+-- Per-exchange DPoP nonces are kept in request-scoped storage (ngx.ctx) so
+-- that an opts table shared across requests/workers is never mutated with
+-- transient state. The durable, per-user token nonce still lives in the
+-- session; opts.dpop_nonce remains a static, caller-provided seed.
+local function openidc_get_dpop_nonce(opts, key)
+  local nonces = ngx.ctx.openidc_dpop_nonces
+  return (nonces and nonces[key]) or opts.dpop_nonce
+end
+
+local function openidc_set_dpop_nonce(key, nonce)
+  if not nonce then
+    return
+  end
+  local nonces = ngx.ctx.openidc_dpop_nonces
+  if not nonces then
+    nonces = {}
+    ngx.ctx.openidc_dpop_nonces = nonces
+  end
+  nonces[key] = nonce
+end
+
 local function openidc_validate_dpop_token_response(json)
   if not json or not json.access_token then
     return nil
@@ -840,7 +861,7 @@ function openidc.call_token_endpoint(opts, endpoint, body, auth, endpoint_name, 
     if ep_name == "token" and opts.use_dpop then
       local proof
       proof, err = openidc_dpop_proof(opts, "POST", endpoint, nil,
-          dpop_nonce or opts.dpop_token_nonce or opts.dpop_nonce)
+          dpop_nonce or openidc_get_dpop_nonce(opts, "token"))
       if err then
         return nil, err, true
       end
@@ -876,7 +897,7 @@ function openidc.call_token_endpoint(opts, endpoint, body, auth, endpoint_name, 
 
   local dpop_nonce = ep_name == "token" and opts.use_dpop and openidc_dpop_nonce_from_response(res, { 400, 401 })
   if dpop_nonce then
-    opts.dpop_token_nonce = dpop_nonce
+    openidc_set_dpop_nonce("token", dpop_nonce)
     log(DEBUG, "retrying " .. ep_name .. " endpoint call with DPoP nonce")
     res, err, proof_err = request_token_endpoint(dpop_nonce)
     if proof_err then
@@ -891,7 +912,7 @@ function openidc.call_token_endpoint(opts, endpoint, body, auth, endpoint_name, 
 
   local next_dpop_nonce = ep_name == "token" and opts.use_dpop and openidc_dpop_nonce_from_response(res, { 200 })
   if next_dpop_nonce then
-    opts.dpop_token_nonce = next_dpop_nonce
+    openidc_set_dpop_nonce("token", next_dpop_nonce)
   end
   local response_dpop_nonce = next_dpop_nonce or dpop_nonce
 
@@ -1005,7 +1026,7 @@ function openidc.call_userinfo_endpoint(opts, access_token)
     end
 
     local proof, proof_err = openidc_dpop_proof(opts, "GET", opts.discovery.userinfo_endpoint, access_token,
-        dpop_nonce or opts.dpop_userinfo_nonce or opts.dpop_nonce)
+        dpop_nonce or openidc_get_dpop_nonce(opts, "userinfo"))
     if proof_err then
       return nil, proof_err
     end
@@ -1044,7 +1065,7 @@ function openidc.call_userinfo_endpoint(opts, access_token)
 
   local dpop_nonce = opts.use_dpop and openidc_dpop_nonce_from_response(res, { 401 })
   if dpop_nonce then
-    opts.dpop_userinfo_nonce = dpop_nonce
+    openidc_set_dpop_nonce("userinfo", dpop_nonce)
     log(DEBUG, "retrying userinfo endpoint call with DPoP nonce")
     headers, headers_err = userinfo_headers(dpop_nonce)
     if headers_err then
@@ -1865,7 +1886,7 @@ local function openidc_access_token(opts, session, try_to_renew)
     scope = opts.scope and opts.scope or "openid email profile"
   }
   if opts.use_dpop then
-    opts.dpop_token_nonce = session:get("dpop_token_nonce") or opts.dpop_token_nonce
+    openidc_set_dpop_nonce("token", session:get("dpop_token_nonce"))
   end
 
   local json

--- a/tests/spec/dpop_spec.lua
+++ b/tests/spec/dpop_spec.lua
@@ -383,6 +383,40 @@ describe("when the authorization server provides the next DPoP nonce on success"
   end)
 end)
 
+describe("when two independent sessions obtain DPoP nonces in sequence", function()
+  local token_headers, first_payload, second_payload
+
+  setup(function()
+    -- share_oidc_opts reuses a single opts table across requests, modeling a
+    -- deployment that defines opts once at module/init scope. Without it the
+    -- harness rebuilds opts per request, which would hide a cross-request leak.
+    test_support.start_server({
+      share_oidc_opts = true,
+      token_dpop_nonce_success = "session-one-nonce",
+      oidc_opts = generate_dpop_opts(),
+    })
+    -- first user logs in; the token endpoint hands out a DPoP nonce on success
+    test_support.login()
+    -- a second, independent user logs in with a fresh session
+    test_support.login()
+
+    token_headers = logged_dpop_headers("token")
+    _, first_payload = decode_jwt(token_headers[1])
+    _, second_payload = decode_jwt(token_headers[2])
+  end)
+
+  teardown(test_support.stop_server)
+
+  it("does not leak the first session's nonce into the second session's token request", function()
+    assert.are.equals(2, #token_headers)
+    -- neither code exchange should carry a nonce: the first session has none
+    -- yet, and the second must not inherit the first's via shared opts state
+    assert.is_nil(first_payload.nonce)
+    assert.are_not.equals("session-one-nonce", second_payload.nonce)
+    assert.is_nil(second_payload.nonce)
+  end)
+end)
+
 describe("when the userinfo endpoint requests a DPoP nonce", function()
   local userinfo_headers, first_payload, second_payload
 

--- a/tests/spec/test_support.lua
+++ b/tests/spec/test_support.lua
@@ -618,6 +618,9 @@ end
 -- starts a server instance with some customizations of the configuration.
 -- expects custom_config to be a table with:
 -- - oidc_opts is a table containing options that are accepted by oidc.authenticate
+-- - share_oidc_opts reuses a single oidc_opts table across requests (modeling a
+--   deployment that defines opts once at module/init scope) rather than rebuilding
+--   it per request; defaults to false
 -- - remove_oidc_config_keys is an array of keys to remove from the oidc configuration
 -- - id_token is a table containing id_token claims
 -- - remove_id_token_claims is an array of claims to remove from the id_token

--- a/tests/spec/test_support.lua
+++ b/tests/spec/test_support.lua
@@ -91,6 +91,8 @@ local DEFAULT_REFRESH_RESPONSE_CONTAINS_ID_TOKEN = "true"
 
 local DEFAULT_UNAUTH_ACTION = "nil"
 
+local DEFAULT_SHARE_OIDC_OPTS = "false"
+
 local DEFAULT_DELAY_RESPONSE = "0"
 
 local DEFAULT_INIT_TEMPLATE = [[
@@ -191,7 +193,16 @@ http {
 
         location /default {
             access_by_lua_block {
-              local opts = OIDC_CONFIG
+              -- with SHARE_OIDC_OPTS the opts table is built once and reused
+              -- across requests, modeling a deployment that defines opts at
+              -- module/init scope rather than per request
+              local opts = test_globals.shared_oidc_opts
+              if not opts then
+                opts = OIDC_CONFIG
+                if SHARE_OIDC_OPTS then
+                  test_globals.shared_oidc_opts = opts
+                end
+              end
               if opts.decorate then
                 opts.http_request_decorator = opts.decorate == "body" and test_globals.body_decorator or test_globals.query_decorator
               end
@@ -600,6 +611,7 @@ local function write_template(out, template, custom_config)
     :gsub("ID_TOKEN", serpent.block(id_token, {comment = false }))
     :gsub("ACCESS_TOKEN", serpent.block(access_token, {comment = false }))
     :gsub("UNAUTH_ACTION", custom_config["unauth_action"] and ('"' .. custom_config["unauth_action"] .. '"') or DEFAULT_UNAUTH_ACTION)
+    :gsub("SHARE_OIDC_OPTS", custom_config["share_oidc_opts"] and "true" or DEFAULT_SHARE_OIDC_OPTS)
   out:write(content)
 end
 


### PR DESCRIPTION
## Summary

DPoP nonces were cached on the `opts` table (`opts.dpop_token_nonce` / `opts.dpop_userinfo_nonce`). When a deployment defines `opts` once at module/init scope and reuses it across requests — a common, documented pattern — that is shared mutable state across concurrent requests in a worker. The sharpest edge was the refresh-path seed:

```lua
opts.dpop_token_nonce = session:get("dpop_token_nonce") or opts.dpop_token_nonce
```

The `or opts.dpop_token_nonce` fallback means that if the current user's session has no nonce, the request inherits whatever nonce the **previous** request left on `opts` — i.e. one user's DPoP nonce bleeding into another user's token request.

The durable, per-user nonce already lives in the **session** (`session:set/get("dpop_token_nonce")`); the `opts.dpop_*_nonce` fields were only a transient bridge from session → `call_token_endpoint`. This PR moves that transient state into request-scoped `ngx.ctx` via two small helpers (`openidc_get_dpop_nonce` / `openidc_set_dpop_nonce`). The session persistence and the static, caller-provided `opts.dpop_nonce` seed are untouched, so **no legitimate cross-request optimization is lost** — the session still carries the token nonce between requests.

### Regression test

Added a test driving two independent sessions through one server and asserting the second session's token request does not inherit the first's nonce.

Because the test harness rebuilds `opts` per request, the shared-`opts` leak can't be reproduced as-is, so the test uses a new opt-in `share_oidc_opts` harness flag (default off; all other tests unaffected) that reuses a single `opts` table across requests, modeling the "define opts once" deployment. The test **fails against the previous opts-mutating code** (`second_payload.nonce == "session-one-nonce"`) and passes now.

## Checklist

- [x] Tests pass with `docker build -f tests/Dockerfile . -t lua-resty-openidc/test`
- [x] Tests pass with `docker run -t --rm lua-resty-openidc/test:latest` — `550 successes / 0 failures / 0 errors / 1 pending` (the pending is the pre-existing upstream test)
- [x] `ChangeLog` is updated
