### PR TITLE
Fix concurrent authorization state handling

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,9 @@ unreleased
   with client_jwt_assertion_alg.
 - rebuild client assertion JWTs when retrying token endpoint calls after a
   DPoP nonce challenge.
+- keep pending authorization states separate within the same browser
+  session so concurrent tabs do not overwrite state, nonce, PKCE verifier,
+  or original redirect URI values; see #553.
 
 09/13/204
 - cross-tenant requests are fixed with lua-resty session 4.0.x; closes #526

--- a/ChangeLog
+++ b/ChangeLog
@@ -33,6 +33,9 @@ unreleased
 - keep pending authorization states separate within the same browser
   session so concurrent tabs do not overwrite state, nonce, PKCE verifier,
   or original redirect URI values; see #553.
+- prune stale and excess pending authorization states from the session during
+  authorization requests, configurable with authorization_state_expires_in and
+  authorization_state_max_number; see #553.
 
 09/13/204
 - cross-tenant requests are fixed with lua-resty session 4.0.x; closes #526

--- a/README.md
+++ b/README.md
@@ -213,6 +213,16 @@ h2JHukolz9xf6qN61QMLSd83+kwoBr2drp6xg3eGDLIkQCQLrkY=
              -- Connect provider that ignores the paramter as the
              -- id_token will be rejected otherwise.
 
+             --authorization_state_expires_in = 300
+             -- Maximum age in seconds for pending authorization state stored
+             -- in the session. Expired authorization states are removed when
+             -- a new authorization request is created.
+
+             --authorization_state_max_number = 10
+             -- Maximum number of pending authorization states stored in the
+             -- session. When exceeded, the oldest authorization states are
+             -- removed when a new authorization request is created.
+
              --revoke_tokens_on_logout = false
              -- When revoke_tokens_on_logout is set to true a logout notifies the authorization server that previously obtained refresh and access tokens are no longer needed. This requires that revocation_endpoint is discoverable.
              -- If there is no revocation endpoint supplied or if there are errors on revocation the user will not be notified and the logout process continues normally.

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -616,12 +616,22 @@ local function openidc_authorize(opts, session, target_url, prompt)
     params.dpop_jkt = dpop_jkt
   end
 
+  local now = ngx.time()
+  local authorization_states = session:get("authorization_states") or {}
+  authorization_states[state] = {
+    nonce = nonce,
+    code_verifier = code_verifier,
+    original_url = target_url,
+    created_at = now
+  }
+
   -- store state in the session
+  session:set("authorization_states", authorization_states)
   session:set("original_url", target_url)
   session:set("state", state)
   session:set("nonce", nonce)
   session:set("code_verifier", code_verifier)
-  session:set("last_authenticated", ngx.time())
+  session:set("last_authenticated", now)
 
   if opts.lifecycle and opts.lifecycle.on_created then
     err = opts.lifecycle.on_created(session, params)
@@ -1496,11 +1506,11 @@ end
 -- Parameters :
 --     - opts the openidc module options
 --     - jwt_id_token the id_token from the id_token properties of the token endpoint response
---     - session the current session
+--     - nonce the nonce sent in the authorization request
 -- Return the id_token, nil if valid
 -- Return nil, the error if invalid
 --
-local function openidc_load_and_validate_jwt_id_token(opts, jwt_id_token, session)
+local function openidc_load_and_validate_jwt_id_token(opts, jwt_id_token, nonce)
 
   local jwt_obj, err = openidc_load_jwt_and_verify_crypto(opts, jwt_id_token, opts.public_key, opts.client_secret,
     opts.discovery.id_token_signing_alg_values_supported)
@@ -1526,13 +1536,32 @@ local function openidc_load_and_validate_jwt_id_token(opts, jwt_id_token, sessio
   log(DEBUG, "id_token payload: ", cjson.encode(jwt_obj.payload))
 
   -- validate the id_token contents
-  if openidc_validate_id_token(opts, id_token, session:get("nonce")) == false then
+  if openidc_validate_id_token(opts, id_token, nonce) == false then
     err = "id_token validation failed"
     log(ERROR, err)
     return nil, err
   end
 
   return id_token
+end
+
+local function openidc_authorization_state(session, state)
+  local authorization_states = session:get("authorization_states") or {}
+  local authorization_state = authorization_states[state]
+  if authorization_state then
+    return authorization_state, authorization_states
+  end
+
+  local legacy_state = session:get("state")
+  if state == legacy_state then
+    return {
+      nonce = session:get("nonce"),
+      code_verifier = session:get("code_verifier"),
+      original_url = session:get("original_url")
+    }, authorization_states
+  end
+
+  return nil, authorization_states, legacy_state
 end
 
 -- handle a "code" authorization response from the OP
@@ -1553,17 +1582,18 @@ local function openidc_authorization_response(opts, session)
   end
 
   -- check that the state returned in the response against the session; prevents CSRF
-  local state = session:get("state")
-  if args.state ~= state then
-    log_err = "state from argument: " .. (args.state and args.state or "nil") .. " does not match state restored from session: " .. (state and state or "nil")
+  local authorization_state, authorization_states, restored_state = openidc_authorization_state(session, args.state)
+  if not authorization_state then
+    log_err = "state from argument: " .. (args.state and args.state or "nil") .. " does not match state restored from session: " .. (restored_state and restored_state or "nil")
     client_err = "state from argument does not match state restored from session"
     log(ERROR, log_err)
     return nil, client_err, session:get("original_url"), session
   end
+  local original_url = authorization_state.original_url or session:get("original_url")
 
   err = ensure_config(opts)
   if err then
-    return nil, err, session:get("original_url"), session
+    return nil, err, original_url, session
   end
 
   -- check the iss if returned from the OP
@@ -1571,7 +1601,7 @@ local function openidc_authorization_response(opts, session)
     log_err = "iss from argument: " .. args.iss .. " does not match expected issuer: " .. opts.discovery.issuer
     client_err = "iss from argument does not match expected issuer"
     log(ERROR, log_err)
-    return nil, client_err, session:get("original_url"), session
+    return nil, client_err, original_url, session
   end
 
   -- check the client_id if returned from the OP
@@ -1579,7 +1609,7 @@ local function openidc_authorization_response(opts, session)
     log_err = "client_id from argument: " .. args.client_id .. " does not match expected client_id: " .. opts.client_id
     client_err = "client_id from argument does not match expected client_id"
     log(ERROR, log_err)
-    return nil, client_err, session:get("original_url"), session
+    return nil, client_err, original_url, session
   end
 
   -- assemble the parameters to the token endpoint
@@ -1587,8 +1617,8 @@ local function openidc_authorization_response(opts, session)
     grant_type = "authorization_code",
     code = args.code,
     redirect_uri = openidc_get_redirect_uri(opts, session),
-    state = state,
-    code_verifier = session:get("code_verifier")
+    state = args.state,
+    code_verifier = authorization_state.code_verifier
   }
 
   log(DEBUG, "Authentication with OP done -> Calling OP Token Endpoint to obtain tokens")
@@ -1598,19 +1628,27 @@ local function openidc_authorization_response(opts, session)
   local json
   json, err = openidc.call_token_endpoint(opts, opts.discovery.token_endpoint, body, opts.token_endpoint_auth_method)
   if err then
-    return nil, err, session:get("original_url"), session
+    return nil, err, original_url, session
   end
 
-  local id_token, err = openidc_load_and_validate_jwt_id_token(opts, json.id_token, session);
+  local id_token, err = openidc_load_and_validate_jwt_id_token(opts, json.id_token, authorization_state.nonce);
   if err then
-    return nil, err, session:get("original_url"), session
+    return nil, err, original_url, session
   end
 
   -- mark this sessions as authenticated
   session:set("authenticated", true)
-  session:set("nonce", nil)
-  session:set("state", nil)
-  session:set("code_verifier", nil)
+  authorization_states[args.state] = nil
+  if next(authorization_states) then
+    session:set("authorization_states", authorization_states)
+  else
+    session:set("authorization_states", nil)
+  end
+  if session:get("state") == args.state then
+    session:set("nonce", nil)
+    session:set("state", nil)
+    session:set("code_verifier", nil)
+  end
 
   if store_in_session(opts, 'id_token') then
     session:set("id_token", id_token)
@@ -1655,7 +1693,7 @@ local function openidc_authorization_response(opts, session)
     err = opts.lifecycle.on_authenticated(session, id_token, json)
     if err then
       log(WARN, "failed in `on_authenticated` handler: " .. err)
-      return nil, err, session:get("original_url"), session
+      return nil, err, original_url, session
     end
   end
 
@@ -1667,7 +1705,6 @@ local function openidc_authorization_response(opts, session)
   end
 
   -- redirect to the URL that was accessed originally
-  local original_url = session:get("original_url")
   log(DEBUG, "OIDC Authorization Code Flow completed -> Redirecting to original URL (" .. original_url .. ")")
   ngx.redirect(original_url)
   return nil, nil, original_url, session
@@ -1896,7 +1933,7 @@ local function openidc_access_token(opts, session, try_to_renew)
   end
   local id_token
   if json.id_token then
-    id_token, err = openidc_load_and_validate_jwt_id_token(opts, json.id_token, session)
+    id_token, err = openidc_load_and_validate_jwt_id_token(opts, json.id_token, session:get("nonce"))
     if err then
       log(ERROR, "invalid id token, discarding tokens returned while refreshing")
       return nil, err

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -560,6 +560,45 @@ local function openidc_pushed_authorization_request(opts, params)
   return json
 end
 
+local function openidc_prune_authorization_states(opts, authorization_states, current_state)
+  local max_age = opts.authorization_state_expires_in or 300
+  local max_number = opts.authorization_state_max_number or 10
+  local now = ngx.time()
+
+  if max_age < 0 then
+    max_age = 0
+  end
+  if max_number < 1 then
+    max_number = 1
+  end
+
+  for state, data in pairs(authorization_states) do
+    if not data.created_at or now - data.created_at > max_age then
+      authorization_states[state] = nil
+    end
+  end
+
+  local count = 0
+  for _ in pairs(authorization_states) do
+    count = count + 1
+  end
+
+  while count > max_number do
+    local oldest_state, oldest_at
+    for state, data in pairs(authorization_states) do
+      local created_at = data.created_at or 0
+      if state ~= current_state and (not oldest_at or created_at < oldest_at) then
+        oldest_state, oldest_at = state, created_at
+      end
+    end
+    if not oldest_state then
+      break
+    end
+    authorization_states[oldest_state] = nil
+    count = count - 1
+  end
+end
+
 -- send the browser of to the OP's authorization endpoint
 local function openidc_authorize(opts, session, target_url, prompt)
   local resty_random = require("resty.random")
@@ -624,6 +663,7 @@ local function openidc_authorize(opts, session, target_url, prompt)
     original_url = target_url,
     created_at = now
   }
+  openidc_prune_authorization_states(opts, authorization_states, state)
 
   -- store state in the session
   session:set("authorization_states", authorization_states)

--- a/tests/spec/pkce_spec.lua
+++ b/tests/spec/pkce_spec.lua
@@ -44,6 +44,14 @@ local function assert_token_endpoint_call_doesnt_contain(s, case_insensitive)
                                     case_insensitive)
 end
 
+local function as_base64(s)
+  local rem = #s % 4
+  if rem > 0 then
+    s = s .. string.rep('=', 4 - rem)
+  end
+  return s:gsub('%-', '+'):gsub('_', '/')
+end
+
 describe('when pkce is disabled and the token endpoint is invoked', function()
   test_support.start_server()
   teardown(test_support.stop_server)
@@ -76,14 +84,52 @@ describe('when pkce is enabled and the token endpoint is invoked', function()
     assert.truthy(code_verifier)
   end)
   it('hashing the code verifier leads to the challenge', function()
-    local as_base64 = function(s)
-      local rem = #s % 4
-      if rem > 0 then
-        s = s .. string.rep('=', 4 - rem)
-      end
-      return s:gsub('%-', '+'):gsub('_', '/')
-    end
     local challenge = as_base64(code_challenge)
+    local hashed_verifier = (require 'mime').b64((require 'sha2').bytes(code_verifier))
+    assert.are.equals(hashed_verifier, challenge)
+  end)
+end)
+
+describe('when pkce is enabled for multiple authorization requests in the same session', function()
+  test_support.start_server({oidc_opts = { use_pkce = true } })
+  teardown(test_support.stop_server)
+
+  local _, _, first_headers = http.request({
+    url = "http://127.0.0.1/default/t",
+    redirect = false
+  })
+  local first_state = test_support.grab(first_headers, 'state')
+  local first_code_challenge = test_support.grab(first_headers, 'code_challenge')
+  local first_cookie_header = test_support.extract_cookies(first_headers)
+
+  local _, _, second_headers = http.request({
+    url = "http://127.0.0.1/default/other",
+    headers = { cookie = first_cookie_header },
+    redirect = false
+  })
+  local second_state = test_support.grab(second_headers, 'state')
+  local second_cookie_header = test_support.extract_cookies(second_headers)
+
+  test_support.register_nonce(first_headers)
+  http.request({
+        url = "http://127.0.0.1/default/redirect_uri?code=foo&state=" .. first_state,
+        headers = { cookie = second_cookie_header },
+        redirect = false
+  })
+
+  local log = test_support.load("/tmp/server/logs/error.log")
+  local code_verifier = log:match('Received token request: .*code_verifier=([^&]-)[&,]')
+
+  it('generates a new state for each authorization request', function()
+    assert.are_not.equals(first_state, second_state)
+  end)
+
+  it('the request contains a code_verifier', function()
+    assert.truthy(code_verifier)
+  end)
+
+  it('uses the code_verifier for the first authorization request', function()
+    local challenge = as_base64(first_code_challenge)
     local hashed_verifier = (require 'mime').b64((require 'sha2').bytes(code_verifier))
     assert.are.equals(hashed_verifier, challenge)
   end)

--- a/tests/spec/redirect_from_op_spec.lua
+++ b/tests/spec/redirect_from_op_spec.lua
@@ -1,4 +1,5 @@
 local http = require("socket.http")
+local socket = require("socket")
 local test_support = require("test_support")
 local ltn12 = require("ltn12")
 require 'busted.runner'()
@@ -109,6 +110,136 @@ describe("when multiple authorization requests share the same session", function
 
   it("redirects to the first authorization request's original URI", function()
     assert.are.equals("/default/t", h.location)
+  end)
+end)
+
+describe("when pending authorization states exceed the configured limit", function()
+  test_support.start_server({
+    oidc_opts = {
+      authorization_state_max_number = 1
+    }
+  })
+  teardown(test_support.stop_server)
+
+  local _, _, first_headers = http.request({
+    url = "http://localhost/default/t",
+    redirect = false
+  })
+  local first_state = test_support.grab(first_headers, 'state')
+  local first_cookie_header = test_support.extract_cookies(first_headers)
+
+  local _, _, second_headers = http.request({
+    url = "http://localhost/default/other",
+    headers = { cookie = first_cookie_header },
+    redirect = false
+  })
+  local second_state = test_support.grab(second_headers, 'state')
+  local second_cookie_header = test_support.extract_cookies(second_headers)
+
+  local _, first_redir_status = http.request({
+    url = "http://localhost/default/redirect_uri?code=foo&state=" .. first_state,
+    headers = { cookie = second_cookie_header },
+    redirect = false
+  })
+
+  test_support.register_nonce(second_headers)
+  local _, second_redir_status, second_redir_headers = http.request({
+    url = "http://localhost/default/redirect_uri?code=foo&state=" .. second_state,
+    headers = { cookie = second_cookie_header },
+    redirect = false
+  })
+
+  it("rejects the oldest authorization response", function()
+    assert.are.equals(401, first_redir_status)
+  end)
+
+  it("keeps the newest authorization response usable", function()
+    assert.are.equals(302, second_redir_status)
+    assert.are.equals("/default/other", second_redir_headers.location)
+  end)
+end)
+
+describe("when pending authorization states exceed the configured limit in the same second", function()
+  test_support.start_server({
+    fixed_ngx_time = os.time(),
+    oidc_opts = {
+      authorization_state_max_number = 1
+    }
+  })
+  teardown(test_support.stop_server)
+
+  local _, _, first_headers = http.request({
+    url = "http://localhost/default/t",
+    redirect = false
+  })
+  local first_cookie_header = test_support.extract_cookies(first_headers)
+
+  local _, _, second_headers = http.request({
+    url = "http://localhost/default/other",
+    headers = { cookie = first_cookie_header },
+    redirect = false
+  })
+  local second_state = test_support.grab(second_headers, 'state')
+  local second_cookie_header = test_support.extract_cookies(second_headers)
+
+  test_support.register_nonce(second_headers)
+  local _, second_redir_status, second_redir_headers = http.request({
+    url = "http://localhost/default/redirect_uri?code=foo&state=" .. second_state,
+    headers = { cookie = second_cookie_header },
+    redirect = false
+  })
+
+  it("keeps the just-created authorization response usable", function()
+    assert.are.equals(302, second_redir_status)
+    assert.are.equals("/default/other", second_redir_headers.location)
+  end)
+end)
+
+describe("when a pending authorization state has expired", function()
+  test_support.start_server({
+    oidc_opts = {
+      authorization_state_expires_in = 0
+    }
+  })
+  teardown(test_support.stop_server)
+
+  local _, _, first_headers = http.request({
+    url = "http://localhost/default/t",
+    redirect = false
+  })
+  local first_state = test_support.grab(first_headers, 'state')
+  local first_cookie_header = test_support.extract_cookies(first_headers)
+
+  socket.sleep(1.1)
+
+  local _, _, second_headers = http.request({
+    url = "http://localhost/default/other",
+    headers = { cookie = first_cookie_header },
+    redirect = false
+  })
+  local second_state = test_support.grab(second_headers, 'state')
+  local second_cookie_header = test_support.extract_cookies(second_headers)
+
+  local _, first_redir_status = http.request({
+    url = "http://localhost/default/redirect_uri?code=foo&state=" .. first_state,
+    headers = { cookie = second_cookie_header },
+    redirect = false
+  })
+
+  test_support.register_nonce(second_headers)
+  local _, second_redir_status, second_redir_headers = http.request({
+    url = "http://localhost/default/redirect_uri?code=foo&state=" .. second_state,
+    headers = { cookie = second_cookie_header },
+    redirect = false
+  })
+
+  it("rejects the expired authorization response", function()
+    assert.are.equals(401, first_redir_status)
+  end)
+
+  it("keeps the fresh authorization response usable", function()
+    assert.are.equals(302, second_redir_status)
+    assert.are.equals("/default/other", second_redir_headers.location)
   end)
 end)
 

--- a/tests/spec/redirect_from_op_spec.lua
+++ b/tests/spec/redirect_from_op_spec.lua
@@ -73,6 +73,45 @@ describe("when a redirect is received", function()
   end)
 end)
 
+describe("when multiple authorization requests share the same session", function()
+  test_support.start_server()
+  teardown(test_support.stop_server)
+
+  local _, _, first_headers = http.request({
+    url = "http://localhost/default/t",
+    redirect = false
+  })
+  local first_state = test_support.grab(first_headers, 'state')
+  local first_cookie_header = test_support.extract_cookies(first_headers)
+
+  local _, _, second_headers = http.request({
+    url = "http://localhost/default/other",
+    headers = { cookie = first_cookie_header },
+    redirect = false
+  })
+  local second_state = test_support.grab(second_headers, 'state')
+  local second_cookie_header = test_support.extract_cookies(second_headers)
+
+  test_support.register_nonce(first_headers)
+  local _, redirStatus, h = http.request({
+        url = "http://localhost/default/redirect_uri?code=foo&state=" .. first_state,
+        headers = { cookie = second_cookie_header },
+        redirect = false
+  })
+
+  it("generates a new state for each authorization request", function()
+    assert.are_not.equals(first_state, second_state)
+  end)
+
+  it("accepts the first authorization response", function()
+    assert.are.equals(302, redirStatus)
+  end)
+
+  it("redirects to the first authorization request's original URI", function()
+    assert.are.equals("/default/t", h.location)
+  end)
+end)
+
 describe("when the full login has been performed and the initial link is called", function()
   test_support.start_server()
   teardown(test_support.stop_server)

--- a/tests/spec/test_support.lua
+++ b/tests/spec/test_support.lua
@@ -105,6 +105,12 @@ if os.getenv('coverage') then
 end
 test_globals.oidc = require "resty.openidc"
 test_globals.cjson = require "cjson"
+if FIXED_NGX_TIME ~= nil then
+  local fixed_ngx_time = FIXED_NGX_TIME
+  ngx.time = function()
+    return fixed_ngx_time
+  end
+end
 test_globals.delay = function(delay_response)
   if delay_response > 0 then
     ngx.sleep(delay_response / 1000)
@@ -610,6 +616,7 @@ local function write_template(out, template, custom_config)
     :gsub("REFRESH_ID_TOKEN", serpent.block(refresh_id_token, {comment = false }))
     :gsub("ID_TOKEN", serpent.block(id_token, {comment = false }))
     :gsub("ACCESS_TOKEN", serpent.block(access_token, {comment = false }))
+    :gsub("FIXED_NGX_TIME", custom_config["fixed_ngx_time"] or "nil")
     :gsub("UNAUTH_ACTION", custom_config["unauth_action"] and ('"' .. custom_config["unauth_action"] .. '"') or DEFAULT_UNAUTH_ACTION)
     :gsub("SHARE_OIDC_OPTS", custom_config["share_oidc_opts"] and "true" or DEFAULT_SHARE_OIDC_OPTS)
   out:write(content)


### PR DESCRIPTION
﻿## Summary
- store pending authorization requests by `state` within the session
- restore nonce, PKCE code verifier, and original redirect URI from the matching authorization state
- keep the legacy single-value session keys visible for lifecycle hook and in-flight session compatibility

## Root cause
Concurrent authorization redirects in the same browser session reused fixed session keys (`state`, `nonce`, `code_verifier`, and `original_url`). Starting a second login flow overwrote the first flow's values, causing the first callback to fail state validation or use the wrong transaction data.

## Validation
- `docker build -f tests/Dockerfile . -t lua-resty-openidc/test`
- `docker run -t --rm lua-resty-openidc/test:latest` (`556 successes / 0 failures / 0 errors / 1 pending`)

Fixes #553
