### PR TITLE
Fix JWT validator cache bypass

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,7 @@
 unreleased
+- do not use the shared JWT verification cache for bearer JWT validation
+  calls that pass additional claim validators, preventing a token accepted
+  by one validator set from bypassing a stricter validator set on cache hit.
 - scope DPoP nonces to the current request (via ngx.ctx) instead of
   mutating the shared opts table, preventing one session's DPoP nonce
   from leaking into another request; the per-user token nonce continues

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -2428,7 +2428,11 @@ end
 function openidc.jwt_verify(access_token, opts, ...)
   local err
   local json
-  local v = get_cached_jwt_verification(opts, access_token)
+  local has_claim_specs = select("#", ...) > 0
+  local v
+  if not has_claim_specs then
+    v = get_cached_jwt_verification(opts, access_token)
+  end
 
   local slack = opts.iat_slack and opts.iat_slack or 120
   if not v then
@@ -2440,8 +2444,10 @@ function openidc.jwt_verify(access_token, opts, ...)
       local encoded_json = cjson.encode(json)
       log(DEBUG, "jwt: ", encoded_json)
 
-      set_cached_jwt_verification(opts, access_token, encoded_json,
-                                  json.exp and json.exp - ngx.time() or 120)
+      if not has_claim_specs then
+        set_cached_jwt_verification(opts, access_token, encoded_json,
+                                    json.exp and json.exp - ngx.time() or 120)
+      end
     end
 
   else

--- a/tests/spec/bearer_token_verification_spec.lua
+++ b/tests/spec/bearer_token_verification_spec.lua
@@ -744,3 +744,33 @@ describe("when a request_decorator has been specified when calling the jwks endp
     assert.error_log_contains('jwk uri_args:.*"foo"%s*:%s*"bar"')
   end)
 end)
+
+describe("when different bearer JWT validators share the verification cache", function()
+  test_support.start_server({
+    verify_opts = {
+      public_key = test_support.load("/spec/public_rsa_key.pem")
+    },
+    access_token = {
+      aud = "api-a"
+    }
+  })
+  teardown(test_support.stop_server)
+
+  local jwt = test_support.trim(http.request("http://127.0.0.1/jwt"))
+  local _, accepted_status = http.request({
+    url = "http://127.0.0.1/verify_bearer_token_audience_a",
+    headers = { authorization = "Bearer " .. jwt }
+  })
+  local _, rejected_status = http.request({
+    url = "http://127.0.0.1/verify_bearer_token_audience_b",
+    headers = { authorization = "Bearer " .. jwt }
+  })
+
+  it("the first validator accepts the token", function()
+    assert.are.equals(204, accepted_status)
+  end)
+
+  it("the second validator is not bypassed by the cached first result", function()
+    assert.are.equals(401, rejected_status)
+  end)
+end)

--- a/tests/spec/test_support.lua
+++ b/tests/spec/test_support.lua
@@ -162,6 +162,7 @@ http {
     access_log /tmp/server/logs/access.log;
     lua_package_path '~/lua/?.lua;/tmp/server/conf/?.lua;;';
     lua_shared_dict discovery 1m;
+    lua_shared_dict jwt_verification 1m;
     init_by_lua_block {
         test_globals = require("test_globals")
     }
@@ -383,6 +384,40 @@ http {
                 else
                   ngx.status = 204
                   ngx.log(ngx.ERR, "Valid token: " .. test_globals.cjson.encode(json))
+                end
+            }
+        }
+
+        location /verify_bearer_token_audience_a {
+            content_by_lua_block {
+                local opts = VERIFY_OPTS
+                local validators = require("resty.jwt-validators")
+                local json, err, token = test_globals.oidc.bearer_jwt_verify(opts, {
+                  aud = validators.equals("api-a")
+                })
+                if err then
+                  ngx.status = 401
+                  ngx.log(ngx.ERR, "Invalid token for api-a: " .. err)
+                else
+                  ngx.status = 204
+                  ngx.log(ngx.ERR, "Valid token for api-a: " .. test_globals.cjson.encode(json))
+                end
+            }
+        }
+
+        location /verify_bearer_token_audience_b {
+            content_by_lua_block {
+                local opts = VERIFY_OPTS
+                local validators = require("resty.jwt-validators")
+                local json, err, token = test_globals.oidc.bearer_jwt_verify(opts, {
+                  aud = validators.equals("api-b")
+                })
+                if err then
+                  ngx.status = 401
+                  ngx.log(ngx.ERR, "Invalid token for api-b: " .. err)
+                else
+                  ngx.status = 204
+                  ngx.log(ngx.ERR, "Valid token for api-b: " .. test_globals.cjson.encode(json))
                 end
             }
         }


### PR DESCRIPTION
## Summary

Fixes a JWT verification cache confusion issue where bearer JWT validation calls that pass additional claim validators could reuse a cached payload produced by a different validator set.

## Root cause

jwt_verify applied caller-supplied claim validators only on cache miss. The jwt_verification cache key did not include those validators, and cache hits decoded the cached payload without rerunning them.

## Changes

- Skip the shared JWT verification cache whenever jwt_verify is called with extra claim validators.
- Add regression coverage with two bearer-token endpoints using different audience validators against the same token/cache.
- Update ChangeLog.

## Validation

- docker build -f tests/Dockerfile . -t lua-resty-openidc/test
- docker run -t --rm lua-resty-openidc/test:latest

Result: 563 successes / 0 failures / 0 errors / 1 pending.